### PR TITLE
chore: add issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Problems with the software
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you very much for your feedback!
+
+        For suggestions or help, please consider using [Github Discussion](https://github.com/Brooooooklyn/Image/discussions) instead.
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search [issues](https://github.com/Brooooooklyn/Image/issues) to check if your issue has already been reported.
+      options:
+        - label: >
+            I searched in the [issues](https://github.com/Brooooooklyn/Image/issues) and found nothing similar.
+          required: true
+  - type: textarea
+    attributes:
+      label: Image version
+      description: >
+        Please provide the version of Image you are using. If you are using the main branch, please provide the commit id.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: System version
+      description: >
+        Please provide the version of System you are using.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Node.js version
+      description: >
+        Please provide the Node.js version.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Minimal reproduce step
+      description: Please try to give reproducing steps to facilitate quick location of the problem.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What did you expect to see?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What did you see instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Anything else?
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        We look forward to the community of developers or users helping solve Image problems together. If you are willing to submit a PR to fix this problem, please check the box.
+      options:
+        - label: I'm willing to submit a PR!
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question or get support
+    url: https://github.com/Brooooooklyn/Image/discussions/categories/q-a
+    about: Ask a question or request support for Image

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,45 @@
+name: Feature
+description: Add new feature, improve code, and more
+labels: [ "enhancement" ]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you very much for your feature proposal!
+  - type: checkboxes
+    attributes:
+      label: Search before asking
+      description: >
+        Please search [issues](https://github.com/Brooooooklyn/Image/issues) to check if your issue has already been reported.
+      options:
+        - label: >
+            I searched in the [issues](https://github.com/Brooooooklyn/Image/issues) and found nothing similar.
+          required: true
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: Describe the motivations for this feature, like how it fixes the problem you meet.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Solution
+      description: Describe the proposed solution and add related materials like links if any.
+  - type: textarea
+    attributes:
+      label: Alternatives
+      description: Describe other alternative solutions or features you considered, but rejected.
+  - type: textarea
+    attributes:
+      label: Anything else?
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      description: >
+        We look forward to the community of developers or users helping develop Image features together. If you are willing to submit a PR to implement the feature, please check the box.
+      options:
+        - label: I'm willing to submit a PR!
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"
+


### PR DESCRIPTION
Please try it at https://github.com/liby/Image/issues/new/choose.

Now we require version info and minor reproduce steps for bug reports.

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/38807139/210519986-fa483e12-bebc-40c1-ac62-17c5db55497d.png">

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/38807139/210520054-a99aecdd-5a43-4881-bfd6-aad3e724d7a5.png">

<img width="1294" alt="image" src="https://user-images.githubusercontent.com/38807139/210520236-3e2a34f7-204b-443e-9c64-89238cc300c8.png">
