### PR TITLE
change Buffer to Uint8Array in fromRgbaPixels

### DIFF
--- a/packages/binding/index.d.ts
+++ b/packages/binding/index.d.ts
@@ -365,7 +365,7 @@ export interface ResizeOptions {
 }
 export class Transformer {
   constructor(input: Buffer)
-  static fromRgbaPixels(input: Buffer | Uint8ClampedArray, width: number, height: number): Transformer
+  static fromRgbaPixels(input: Uint8Array | Uint8ClampedArray, width: number, height: number): Transformer
   metadata(withExif?: boolean | undefined | null, signal?: AbortSignal | undefined | null): Promise<Metadata>
   /**
    * Rotate with exif orientation

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -671,7 +671,7 @@ impl Transformer {
 
   #[napi]
   pub fn from_rgba_pixels(
-    input: Either<Buffer, Uint8ClampedArray>,
+    input: Either<Uint8Array, Uint8ClampedArray>,
     width: u32,
     height: u32,
   ) -> Result<Transformer> {


### PR DESCRIPTION
hi

this allows for the following (only needed for typescript):

```js
import { Transformer } from './index.js'

const width = 256
const height = 256
const uint8 = new Uint8Array(width * height * 4)
const transformer = Transformer.fromRgbaPixels(uint8, width, height)
```

this creates an empty 256x256 image. I use it to overlay multiple images without having to resize/stretch/overlap each other

Buffer is still allowed too, since it's a subclass of Uint8Array
```js
const buffer = Buffer.alloc(width * height * 4) // slower
const transformer = Transformer.fromRgbaPixels(buffer, width, height)
```

---

it was possible before but I needed to cast Uint8Array to Buffer for typescript to be happy