### PR TITLE
feat(website): OG image redesign — warm-dark/rust + browser/WASM

### DIFF
--- a/website/pages/index.server.ts
+++ b/website/pages/index.server.ts
@@ -11,12 +11,23 @@ export const loader = defineHandler(async () => ({
 
 export type Props = InferProps<typeof loader>
 
+const SITE_URL = 'https://image.napi.rs'
+const DESCRIPTION =
+  'Encode, compress, resize and convert JPEG/PNG/WebP/AVIF with a native Node addon faster than sharp.'
+
 export const head = defineHead<Props>(() => ({
   title: 'Fast image processing in Rust',
   meta: [
-    { name: 'description', content: 'Encode, compress, resize and convert JPEG/PNG/WebP/AVIF with a native Node addon faster than sharp.' },
-    { property: 'og:image', content: '/img/og.png' },
+    { name: 'description', content: DESCRIPTION },
+    { property: 'og:type', content: 'website' },
+    { property: 'og:site_name', content: '@napi-rs/image' },
+    { property: 'og:url', content: `${SITE_URL}/` },
     { property: 'og:title', content: '@napi-rs/image' },
+    { property: 'og:description', content: DESCRIPTION },
+    { property: 'og:image', content: `${SITE_URL}/img/og.png` },
+    { property: 'og:image:width', content: '1200' },
+    { property: 'og:image:height', content: '630' },
+    { property: 'og:image:alt', content: 'Image processing for Node.js and the browser' },
     { name: 'twitter:card', content: 'summary_large_image' },
   ],
 }))

--- a/website/public/img/og.svg
+++ b/website/public/img/og.svg
@@ -100,7 +100,14 @@
     </g>
   </g>
 
-  <text x="65" y="560" fill="#8c867c" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="13" font-weight="600" letter-spacing="1.9">ONE PIPELINE · ANY RUNTIME</text>
+  <!-- primary CTA (arrow drawn as a path: the Latin font subset has no U+2192) -->
+  <g transform="translate(64 466)">
+    <rect width="250" height="48" rx="12" fill="#E37726"/>
+    <text x="25" y="31" fill="#1a1208" font-family="Inter, Arial, sans-serif" font-size="17" font-weight="600" letter-spacing="-0.2">Try it in your browser</text>
+    <path d="M209 24L227 24M221 18L228 24L221 30" fill="none" stroke="#1a1208" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <text x="66" y="566" fill="#8c867c" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="13" font-weight="600" letter-spacing="1.9">ONE PIPELINE · ANY RUNTIME</text>
 
   <!-- flow panel -->
   <g filter="url(#shadow)">

--- a/website/public/img/og.svg
+++ b/website/public/img/og.svg
@@ -1,0 +1,175 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">@napi-rs/image — Image processing for Node.js</title>
+  <desc id="desc">A clean Open Graph image showing multiple image formats flowing through a single image-processing pipeline.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#071827"/>
+      <stop offset="0.5" stop-color="#091326"/>
+      <stop offset="1" stop-color="#120C22"/>
+    </linearGradient>
+    <radialGradient id="glowCyan" cx="0" cy="0" r="1" gradientTransform="translate(212 96) rotate(39) scale(468 350)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2DD4FF" stop-opacity="0.22"/>
+      <stop offset="1" stop-color="#2DD4FF" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="glowPink" cx="0" cy="0" r="1" gradientTransform="translate(1080 545) rotate(-153) scale(486 340)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F05CCF" stop-opacity="0.2"/>
+      <stop offset="1" stop-color="#F05CCF" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#63E6FF"/>
+      <stop offset="0.5" stop-color="#8B8CFF"/>
+      <stop offset="1" stop-color="#FF66C7"/>
+    </linearGradient>
+    <linearGradient id="accentHorizontal" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#63E6FF"/>
+      <stop offset="0.5" stop-color="#9E8BFF"/>
+      <stop offset="1" stop-color="#FF66C7"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="680" y1="154" x2="1138" y2="524" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#12263B" stop-opacity="0.92"/>
+      <stop offset="1" stop-color="#16172E" stop-opacity="0.88"/>
+    </linearGradient>
+    <linearGradient id="pill" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#FFFFFF" stop-opacity="0.095"/>
+      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.045"/>
+    </linearGradient>
+    <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
+      <path d="M42 0H0V42" fill="none" stroke="#C8E9FF" stroke-opacity="0.035"/>
+    </pattern>
+    <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#000814" flood-opacity="0.42"/>
+    </filter>
+    <filter id="softGlow" x="-100%" y="-100%" width="300%" height="300%">
+      <feGaussianBlur stdDeviation="9"/>
+    </filter>
+    <clipPath id="panelClip">
+      <rect x="660" y="150" width="478" height="372" rx="28"/>
+    </clipPath>
+  </defs>
+
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="url(#glowCyan)"/>
+  <rect width="1200" height="630" fill="url(#glowPink)"/>
+  <rect width="1200" height="630" fill="url(#grid)"/>
+
+  <!-- top brand -->
+  <g transform="translate(64 56)">
+    <rect x="0" y="0" width="58" height="58" rx="17" fill="#0D1A2D" stroke="url(#accent)" stroke-width="2"/>
+    <circle cx="41" cy="17" r="4" fill="#EAFBFF"/>
+    <path d="M13 40L24.2 27.7C25.5 26.3 27.6 26.2 29 27.5L35.2 33.3L40 28.5L47 40" fill="none" stroke="#F4FAFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="77" y="38" fill="#F7FBFF" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" letter-spacing="-0.5">@napi-rs/image</text>
+  </g>
+
+  <!-- domain pill -->
+  <g transform="translate(962 60)">
+    <rect width="174" height="42" rx="21" fill="#FFFFFF" fill-opacity="0.055" stroke="#FFFFFF" stroke-opacity="0.12"/>
+    <circle cx="20" cy="21" r="4" fill="#6EF2BE"/>
+    <text x="34" y="27" fill="#DCE8F5" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="600">image.napi.rs</text>
+  </g>
+
+  <!-- left copy -->
+  <text x="64" y="218" fill="#F7FBFF" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="780" letter-spacing="-2.2">Image processing</text>
+  <text x="64" y="286" fill="url(#accentHorizontal)" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="780" letter-spacing="-2.2">for Node.js</text>
+  <text x="67" y="345" fill="#AFC1D6" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="430" letter-spacing="-0.2">Convert · resize · optimize</text>
+
+  <!-- format chips -->
+  <g transform="translate(64 395)" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">
+    <g>
+      <rect width="78" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
+      <text x="39" y="27" text-anchor="middle" fill="#C8F6FF">PNG</text>
+    </g>
+    <g transform="translate(90 0)">
+      <rect width="82" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
+      <text x="41" y="27" text-anchor="middle" fill="#D2DEFF">JPEG</text>
+    </g>
+    <g transform="translate(184 0)">
+      <rect width="86" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
+      <text x="43" y="27" text-anchor="middle" fill="#DDD2FF">WebP</text>
+    </g>
+    <g transform="translate(282 0)">
+      <rect width="80" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
+      <text x="40" y="27" text-anchor="middle" fill="#F1C8F0">AVIF</text>
+    </g>
+    <g transform="translate(374 0)">
+      <rect width="76" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
+      <text x="38" y="27" text-anchor="middle" fill="#FFD0E8">TIFF</text>
+    </g>
+  </g>
+
+  <text x="65" y="560" fill="#71869E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="650" letter-spacing="1.9">ONE PIPELINE · MANY FORMATS</text>
+
+  <!-- flow panel -->
+  <g filter="url(#shadow)">
+    <rect x="660" y="150" width="478" height="372" rx="28" fill="url(#panel)" stroke="#9CCBFF" stroke-opacity="0.18" stroke-width="1.5"/>
+  </g>
+  <g clip-path="url(#panelClip)">
+    <circle cx="1110" cy="168" r="150" fill="#A67CFF" opacity="0.055"/>
+    <circle cx="688" cy="520" r="135" fill="#35D9FF" opacity="0.045"/>
+  </g>
+
+  <text x="690" y="188" fill="#8EA5BD" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="760" letter-spacing="2">FORMAT FLOW</text>
+
+  <!-- connections under nodes -->
+  <g fill="none" stroke-linecap="round" stroke-width="2.2">
+    <path d="M776 241 C824 241, 827 279, 866 299" stroke="#5BDFFF" stroke-opacity="0.5"/>
+    <path d="M776 313 C824 313, 832 313, 866 313" stroke="#8D91FF" stroke-opacity="0.52"/>
+    <path d="M776 385 C824 385, 827 347, 866 327" stroke="#F36DBB" stroke-opacity="0.48"/>
+    <path d="M934 299 C974 279, 978 241, 1022 241" stroke="#72E8C8" stroke-opacity="0.5"/>
+    <path d="M934 313 C974 313, 984 313, 1022 313" stroke="#6ED9FF" stroke-opacity="0.5"/>
+    <path d="M934 327 C974 347, 978 385, 1022 385" stroke="#E67BD1" stroke-opacity="0.48"/>
+  </g>
+
+  <!-- connection dots -->
+  <g>
+    <circle cx="822" cy="264" r="3" fill="#67E5FF"/>
+    <circle cx="831" cy="313" r="3" fill="#A79BFF"/>
+    <circle cx="822" cy="362" r="3" fill="#FF7FC8"/>
+    <circle cx="978" cy="264" r="3" fill="#79EACB"/>
+    <circle cx="982" cy="313" r="3" fill="#72DBFF"/>
+    <circle cx="978" cy="362" r="3" fill="#EC83D3"/>
+  </g>
+
+  <!-- input nodes -->
+  <g font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">
+    <g>
+      <rect x="690" y="216" width="86" height="50" rx="14" fill="#10273A" stroke="#58D8F2" stroke-opacity="0.35"/>
+      <text x="733" y="247" text-anchor="middle" fill="#A9EDFF">.png</text>
+    </g>
+    <g>
+      <rect x="690" y="288" width="86" height="50" rx="14" fill="#181F3A" stroke="#9997FF" stroke-opacity="0.34"/>
+      <text x="733" y="319" text-anchor="middle" fill="#C5C1FF">.tiff</text>
+    </g>
+    <g>
+      <rect x="690" y="360" width="86" height="50" rx="14" fill="#2A1B35" stroke="#F176C3" stroke-opacity="0.34"/>
+      <text x="733" y="391" text-anchor="middle" fill="#F6B1DB">.hdr</text>
+    </g>
+  </g>
+
+  <!-- center engine glow -->
+  <circle cx="900" cy="313" r="76" fill="#7B93FF" opacity="0.14" filter="url(#softGlow)"/>
+  <rect x="854" y="267" width="92" height="92" rx="28" fill="#0A1427" stroke="url(#accent)" stroke-width="2"/>
+  <circle cx="900" cy="313" r="19" fill="#14233B" stroke="#FFFFFF" stroke-opacity="0.12"/>
+  <circle cx="908" cy="306" r="3" fill="#F4FAFF"/>
+  <path d="M888 323L896 314.5L901 319L905 315L912 323" fill="none" stroke="#F4FAFF" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+
+  <!-- output nodes -->
+  <g font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">
+    <g>
+      <rect x="1022" y="216" width="88" height="50" rx="14" fill="#102C30" stroke="#6DE9C8" stroke-opacity="0.38"/>
+      <text x="1066" y="247" text-anchor="middle" fill="#A6F4DE">.webp</text>
+    </g>
+    <g>
+      <rect x="1022" y="288" width="88" height="50" rx="14" fill="#10283A" stroke="#60D8FF" stroke-opacity="0.38"/>
+      <text x="1066" y="319" text-anchor="middle" fill="#A8EAFF">.avif</text>
+    </g>
+    <g>
+      <rect x="1022" y="360" width="88" height="50" rx="14" fill="#2A1B35" stroke="#E57CD1" stroke-opacity="0.38"/>
+      <text x="1066" y="391" text-anchor="middle" fill="#F1B5E4">.jpg</text>
+    </g>
+  </g>
+
+  <!-- subtle panel footer -->
+  <line x1="690" y1="464" x2="1108" y2="464" stroke="#FFFFFF" stroke-opacity="0.08"/>
+  <circle cx="704" cy="490" r="4" fill="#6FEFC0"/>
+  <text x="717" y="495" fill="#9FB2C8" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="600">Native performance, simple API</text>
+</svg>

--- a/website/public/img/og.svg
+++ b/website/public/img/og.svg
@@ -1,43 +1,46 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
-  <title id="title">@napi-rs/image — Image processing for Node.js</title>
-  <desc id="desc">A clean Open Graph image showing multiple image formats flowing through a single image-processing pipeline.</desc>
+  <title id="title">@napi-rs/image — Image processing for Node.js and the browser</title>
+  <desc id="desc">A warm-dark Open Graph image: a single Rust image-processing pipeline that runs on Node.js and in the browser via WebAssembly, converting between many formats.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#071827"/>
-      <stop offset="0.5" stop-color="#091326"/>
-      <stop offset="1" stop-color="#120C22"/>
+      <stop offset="0" stop-color="#0b0a09"/>
+      <stop offset="0.5" stop-color="#100b08"/>
+      <stop offset="1" stop-color="#150d0a"/>
     </linearGradient>
-    <radialGradient id="glowCyan" cx="0" cy="0" r="1" gradientTransform="translate(212 96) rotate(39) scale(468 350)" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#2DD4FF" stop-opacity="0.22"/>
-      <stop offset="1" stop-color="#2DD4FF" stop-opacity="0"/>
+    <radialGradient id="glowAmber" cx="0" cy="0" r="1" gradientTransform="translate(232 104) rotate(42) scale(470 350)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F89A3C" stop-opacity="0.16"/>
+      <stop offset="1" stop-color="#F89A3C" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="glowPink" cx="0" cy="0" r="1" gradientTransform="translate(1080 545) rotate(-153) scale(486 340)" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#F05CCF" stop-opacity="0.2"/>
-      <stop offset="1" stop-color="#F05CCF" stop-opacity="0"/>
+    <radialGradient id="glowRust" cx="0" cy="0" r="1" gradientTransform="translate(1064 548) rotate(-150) scale(486 340)" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#C2571A" stop-opacity="0.14"/>
+      <stop offset="1" stop-color="#C2571A" stop-opacity="0"/>
     </radialGradient>
-    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#63E6FF"/>
-      <stop offset="0.5" stop-color="#8B8CFF"/>
-      <stop offset="1" stop-color="#FF66C7"/>
+    <linearGradient id="accentWarm" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#F6A24A"/>
+      <stop offset="1" stop-color="#E0641C"/>
     </linearGradient>
-    <linearGradient id="accentHorizontal" x1="0" y1="0" x2="1" y2="0">
-      <stop offset="0" stop-color="#63E6FF"/>
-      <stop offset="0.5" stop-color="#9E8BFF"/>
-      <stop offset="1" stop-color="#FF66C7"/>
+    <linearGradient id="accentWarmH" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#F6A24A"/>
+      <stop offset="1" stop-color="#E0641C"/>
+    </linearGradient>
+    <linearGradient id="flowGrad" x1="690" y1="313" x2="1110" y2="313" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F6A24A"/>
+      <stop offset="0.5" stop-color="#EB7A2A"/>
+      <stop offset="1" stop-color="#E0641C"/>
     </linearGradient>
     <linearGradient id="panel" x1="680" y1="154" x2="1138" y2="524" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#12263B" stop-opacity="0.92"/>
-      <stop offset="1" stop-color="#16172E" stop-opacity="0.88"/>
+      <stop stop-color="#16140f" stop-opacity="0.94"/>
+      <stop offset="1" stop-color="#1b1916" stop-opacity="0.9"/>
     </linearGradient>
     <linearGradient id="pill" x1="0" y1="0" x2="1" y2="1">
-      <stop stop-color="#FFFFFF" stop-opacity="0.095"/>
-      <stop offset="1" stop-color="#FFFFFF" stop-opacity="0.045"/>
+      <stop stop-color="#FFFAF5" stop-opacity="0.07"/>
+      <stop offset="1" stop-color="#FFFAF5" stop-opacity="0.03"/>
     </linearGradient>
     <pattern id="grid" width="42" height="42" patternUnits="userSpaceOnUse">
-      <path d="M42 0H0V42" fill="none" stroke="#C8E9FF" stroke-opacity="0.035"/>
+      <path d="M42 0H0V42" fill="none" stroke="#FFFAF5" stroke-opacity="0.03"/>
     </pattern>
     <filter id="shadow" x="-30%" y="-30%" width="160%" height="160%">
-      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#000814" flood-opacity="0.42"/>
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#040301" flood-opacity="0.5"/>
     </filter>
     <filter id="softGlow" x="-100%" y="-100%" width="300%" height="300%">
       <feGaussianBlur stdDeviation="9"/>
@@ -48,128 +51,129 @@
   </defs>
 
   <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect width="1200" height="630" fill="url(#glowCyan)"/>
-  <rect width="1200" height="630" fill="url(#glowPink)"/>
+  <rect width="1200" height="630" fill="url(#glowAmber)"/>
+  <rect width="1200" height="630" fill="url(#glowRust)"/>
   <rect width="1200" height="630" fill="url(#grid)"/>
 
   <!-- top brand -->
   <g transform="translate(64 56)">
-    <rect x="0" y="0" width="58" height="58" rx="17" fill="#0D1A2D" stroke="url(#accent)" stroke-width="2"/>
-    <circle cx="41" cy="17" r="4" fill="#EAFBFF"/>
-    <path d="M13 40L24.2 27.7C25.5 26.3 27.6 26.2 29 27.5L35.2 33.3L40 28.5L47 40" fill="none" stroke="#F4FAFF" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    <text x="77" y="38" fill="#F7FBFF" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" letter-spacing="-0.5">@napi-rs/image</text>
+    <rect x="0" y="0" width="58" height="58" rx="17" fill="#15110c" stroke="url(#accentWarm)" stroke-width="2"/>
+    <circle cx="41" cy="17" r="4" fill="#FBF3E8"/>
+    <path d="M13 40L24.2 27.7C25.5 26.3 27.6 26.2 29 27.5L35.2 33.3L40 28.5L47 40" fill="none" stroke="#FBF7F1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <text x="77" y="38" fill="#F4F1EC" font-family="'Space Grotesk', Inter, Arial, sans-serif" font-size="30" font-weight="600" letter-spacing="-0.6">@napi-rs/image</text>
   </g>
 
   <!-- domain pill -->
   <g transform="translate(962 60)">
-    <rect width="174" height="42" rx="21" fill="#FFFFFF" fill-opacity="0.055" stroke="#FFFFFF" stroke-opacity="0.12"/>
-    <circle cx="20" cy="21" r="4" fill="#6EF2BE"/>
-    <text x="34" y="27" fill="#DCE8F5" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="600">image.napi.rs</text>
+    <rect width="174" height="42" rx="21" fill="#FFFAF5" fill-opacity="0.05" stroke="#FFFAF5" stroke-opacity="0.12"/>
+    <circle cx="20" cy="21" r="4" fill="#6FEFC0"/>
+    <text x="34" y="27" fill="#D9D2C7" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="14" font-weight="500">image.napi.rs</text>
   </g>
 
   <!-- left copy -->
-  <text x="64" y="218" fill="#F7FBFF" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="780" letter-spacing="-2.2">Image processing</text>
-  <text x="64" y="286" fill="url(#accentHorizontal)" font-family="Inter, Arial, sans-serif" font-size="64" font-weight="780" letter-spacing="-2.2">for Node.js</text>
-  <text x="67" y="345" fill="#AFC1D6" font-family="Inter, Arial, sans-serif" font-size="25" font-weight="430" letter-spacing="-0.2">Convert · resize · optimize</text>
+  <text x="64" y="190" fill="#F4F1EC" font-family="'Space Grotesk', Inter, Arial, sans-serif" font-size="58" font-weight="600" letter-spacing="-1.6">Image processing</text>
+  <text x="64" y="250" fill="#F4F1EC" font-family="'Space Grotesk', Inter, Arial, sans-serif" font-size="58" font-weight="600" letter-spacing="-1.6">for Node.js</text>
+  <text x="64" y="310" fill="url(#accentWarmH)" font-family="'Space Grotesk', Inter, Arial, sans-serif" font-size="58" font-weight="600" letter-spacing="-1.6">&amp; the browser</text>
+  <text x="66" y="360" fill="#A8A298" font-family="Inter, Arial, sans-serif" font-size="23" font-weight="430" letter-spacing="-0.2">One Rust pipeline · WebAssembly · no install</text>
 
   <!-- format chips -->
-  <g transform="translate(64 395)" font-family="Inter, Arial, sans-serif" font-size="15" font-weight="700">
+  <g transform="translate(64 398)" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="15" font-weight="600">
     <g>
-      <rect width="78" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
-      <text x="39" y="27" text-anchor="middle" fill="#C8F6FF">PNG</text>
+      <rect width="78" height="42" rx="14" fill="url(#pill)" stroke="#FFFAF5" stroke-opacity="0.12"/>
+      <text x="39" y="27" text-anchor="middle" fill="#C9C2B6">PNG</text>
     </g>
     <g transform="translate(90 0)">
-      <rect width="82" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
-      <text x="41" y="27" text-anchor="middle" fill="#D2DEFF">JPEG</text>
+      <rect width="82" height="42" rx="14" fill="url(#pill)" stroke="#FFFAF5" stroke-opacity="0.12"/>
+      <text x="41" y="27" text-anchor="middle" fill="#C9C2B6">JPEG</text>
     </g>
     <g transform="translate(184 0)">
-      <rect width="86" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
-      <text x="43" y="27" text-anchor="middle" fill="#DDD2FF">WebP</text>
+      <rect width="86" height="42" rx="14" fill="url(#pill)" stroke="#FFFAF5" stroke-opacity="0.12"/>
+      <text x="43" y="27" text-anchor="middle" fill="#C9C2B6">WebP</text>
     </g>
     <g transform="translate(282 0)">
-      <rect width="80" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
-      <text x="40" y="27" text-anchor="middle" fill="#F1C8F0">AVIF</text>
+      <rect width="80" height="42" rx="14" fill="url(#pill)" stroke="#FFFAF5" stroke-opacity="0.12"/>
+      <text x="40" y="27" text-anchor="middle" fill="#C9C2B6">AVIF</text>
     </g>
     <g transform="translate(374 0)">
-      <rect width="76" height="42" rx="14" fill="url(#pill)" stroke="#FFFFFF" stroke-opacity="0.12"/>
-      <text x="38" y="27" text-anchor="middle" fill="#FFD0E8">TIFF</text>
+      <rect width="76" height="42" rx="14" fill="url(#pill)" stroke="#FFFAF5" stroke-opacity="0.12"/>
+      <text x="38" y="27" text-anchor="middle" fill="#C9C2B6">TIFF</text>
     </g>
   </g>
 
-  <text x="65" y="560" fill="#71869E" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="650" letter-spacing="1.9">ONE PIPELINE · MANY FORMATS</text>
+  <text x="65" y="560" fill="#8c867c" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="13" font-weight="600" letter-spacing="1.9">ONE PIPELINE · ANY RUNTIME</text>
 
   <!-- flow panel -->
   <g filter="url(#shadow)">
-    <rect x="660" y="150" width="478" height="372" rx="28" fill="url(#panel)" stroke="#9CCBFF" stroke-opacity="0.18" stroke-width="1.5"/>
+    <rect x="660" y="150" width="478" height="372" rx="28" fill="url(#panel)" stroke="#FFFAF5" stroke-opacity="0.12" stroke-width="1.5"/>
   </g>
   <g clip-path="url(#panelClip)">
-    <circle cx="1110" cy="168" r="150" fill="#A67CFF" opacity="0.055"/>
-    <circle cx="688" cy="520" r="135" fill="#35D9FF" opacity="0.045"/>
+    <circle cx="1110" cy="168" r="150" fill="#F2913A" opacity="0.05"/>
+    <circle cx="688" cy="520" r="135" fill="#E0641C" opacity="0.045"/>
   </g>
 
-  <text x="690" y="188" fill="#8EA5BD" font-family="Inter, Arial, sans-serif" font-size="12" font-weight="760" letter-spacing="2">FORMAT FLOW</text>
+  <text x="690" y="188" fill="#E37726" font-family="'JetBrains Mono', ui-monospace, monospace" font-size="12" font-weight="700" letter-spacing="2">FORMAT FLOW</text>
 
   <!-- connections under nodes -->
-  <g fill="none" stroke-linecap="round" stroke-width="2.2">
-    <path d="M776 241 C824 241, 827 279, 866 299" stroke="#5BDFFF" stroke-opacity="0.5"/>
-    <path d="M776 313 C824 313, 832 313, 866 313" stroke="#8D91FF" stroke-opacity="0.52"/>
-    <path d="M776 385 C824 385, 827 347, 866 327" stroke="#F36DBB" stroke-opacity="0.48"/>
-    <path d="M934 299 C974 279, 978 241, 1022 241" stroke="#72E8C8" stroke-opacity="0.5"/>
-    <path d="M934 313 C974 313, 984 313, 1022 313" stroke="#6ED9FF" stroke-opacity="0.5"/>
-    <path d="M934 327 C974 347, 978 385, 1022 385" stroke="#E67BD1" stroke-opacity="0.48"/>
+  <g fill="none" stroke="url(#flowGrad)" stroke-linecap="round" stroke-width="2.2" stroke-opacity="0.5">
+    <path d="M776 241 C824 241, 827 279, 866 299"/>
+    <path d="M776 313 C824 313, 832 313, 866 313"/>
+    <path d="M776 385 C824 385, 827 347, 866 327"/>
+    <path d="M934 299 C974 279, 978 241, 1022 241"/>
+    <path d="M934 313 C974 313, 984 313, 1022 313"/>
+    <path d="M934 327 C974 347, 978 385, 1022 385"/>
   </g>
 
   <!-- connection dots -->
-  <g>
-    <circle cx="822" cy="264" r="3" fill="#67E5FF"/>
-    <circle cx="831" cy="313" r="3" fill="#A79BFF"/>
-    <circle cx="822" cy="362" r="3" fill="#FF7FC8"/>
-    <circle cx="978" cy="264" r="3" fill="#79EACB"/>
-    <circle cx="982" cy="313" r="3" fill="#72DBFF"/>
-    <circle cx="978" cy="362" r="3" fill="#EC83D3"/>
+  <g fill="#F2913A">
+    <circle cx="822" cy="264" r="3"/>
+    <circle cx="831" cy="313" r="3"/>
+    <circle cx="822" cy="362" r="3"/>
+    <circle cx="978" cy="264" r="3"/>
+    <circle cx="982" cy="313" r="3"/>
+    <circle cx="978" cy="362" r="3"/>
   </g>
 
-  <!-- input nodes -->
-  <g font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">
+  <!-- input nodes (raw) -->
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="16" font-weight="600">
     <g>
-      <rect x="690" y="216" width="86" height="50" rx="14" fill="#10273A" stroke="#58D8F2" stroke-opacity="0.35"/>
-      <text x="733" y="247" text-anchor="middle" fill="#A9EDFF">.png</text>
+      <rect x="690" y="216" width="86" height="50" rx="14" fill="#1b1916" stroke="#FFFAF5" stroke-opacity="0.14"/>
+      <text x="733" y="247" text-anchor="middle" fill="#E8E3DA">.png</text>
     </g>
     <g>
-      <rect x="690" y="288" width="86" height="50" rx="14" fill="#181F3A" stroke="#9997FF" stroke-opacity="0.34"/>
-      <text x="733" y="319" text-anchor="middle" fill="#C5C1FF">.tiff</text>
+      <rect x="690" y="288" width="86" height="50" rx="14" fill="#1b1916" stroke="#FFFAF5" stroke-opacity="0.14"/>
+      <text x="733" y="319" text-anchor="middle" fill="#E8E3DA">.tiff</text>
     </g>
     <g>
-      <rect x="690" y="360" width="86" height="50" rx="14" fill="#2A1B35" stroke="#F176C3" stroke-opacity="0.34"/>
-      <text x="733" y="391" text-anchor="middle" fill="#F6B1DB">.hdr</text>
+      <rect x="690" y="360" width="86" height="50" rx="14" fill="#1b1916" stroke="#FFFAF5" stroke-opacity="0.14"/>
+      <text x="733" y="391" text-anchor="middle" fill="#E8E3DA">.hdr</text>
     </g>
   </g>
 
   <!-- center engine glow -->
-  <circle cx="900" cy="313" r="76" fill="#7B93FF" opacity="0.14" filter="url(#softGlow)"/>
-  <rect x="854" y="267" width="92" height="92" rx="28" fill="#0A1427" stroke="url(#accent)" stroke-width="2"/>
-  <circle cx="900" cy="313" r="19" fill="#14233B" stroke="#FFFFFF" stroke-opacity="0.12"/>
-  <circle cx="908" cy="306" r="3" fill="#F4FAFF"/>
-  <path d="M888 323L896 314.5L901 319L905 315L912 323" fill="none" stroke="#F4FAFF" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="900" cy="313" r="76" fill="#F2913A" opacity="0.13" filter="url(#softGlow)"/>
+  <rect x="854" y="267" width="92" height="92" rx="28" fill="#15110c" stroke="url(#accentWarm)" stroke-width="2"/>
+  <circle cx="900" cy="313" r="19" fill="#1f1813" stroke="#FFFAF5" stroke-opacity="0.14"/>
+  <circle cx="908" cy="306" r="3" fill="#FBF7F1"/>
+  <path d="M888 323L896 314.5L901 319L905 315L912 323" fill="none" stroke="#FBF7F1" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
 
-  <!-- output nodes -->
-  <g font-family="Inter, Arial, sans-serif" font-size="16" font-weight="700">
+  <!-- output nodes (optimized) -->
+  <g font-family="'JetBrains Mono', ui-monospace, monospace" font-size="16" font-weight="600">
     <g>
-      <rect x="1022" y="216" width="88" height="50" rx="14" fill="#102C30" stroke="#6DE9C8" stroke-opacity="0.38"/>
-      <text x="1066" y="247" text-anchor="middle" fill="#A6F4DE">.webp</text>
+      <rect x="1022" y="216" width="88" height="50" rx="14" fill="#1b1916" stroke="#E37726" stroke-opacity="0.32"/>
+      <text x="1066" y="247" text-anchor="middle" fill="#F6A24A">.webp</text>
     </g>
     <g>
-      <rect x="1022" y="288" width="88" height="50" rx="14" fill="#10283A" stroke="#60D8FF" stroke-opacity="0.38"/>
-      <text x="1066" y="319" text-anchor="middle" fill="#A8EAFF">.avif</text>
+      <rect x="1022" y="288" width="88" height="50" rx="14" fill="#1b1916" stroke="#E37726" stroke-opacity="0.32"/>
+      <text x="1066" y="319" text-anchor="middle" fill="#F6A24A">.avif</text>
     </g>
     <g>
-      <rect x="1022" y="360" width="88" height="50" rx="14" fill="#2A1B35" stroke="#E57CD1" stroke-opacity="0.38"/>
-      <text x="1066" y="391" text-anchor="middle" fill="#F1B5E4">.jpg</text>
+      <rect x="1022" y="360" width="88" height="50" rx="14" fill="#1b1916" stroke="#E37726" stroke-opacity="0.32"/>
+      <text x="1066" y="391" text-anchor="middle" fill="#F6A24A">.jpg</text>
     </g>
   </g>
 
   <!-- subtle panel footer -->
-  <line x1="690" y1="464" x2="1108" y2="464" stroke="#FFFFFF" stroke-opacity="0.08"/>
+  <line x1="690" y1="464" x2="1108" y2="464" stroke="#FFFAF5" stroke-opacity="0.08"/>
   <circle cx="704" cy="490" r="4" fill="#6FEFC0"/>
-  <text x="717" y="495" fill="#9FB2C8" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="600">Native performance, simple API</text>
+  <text x="717" y="495" fill="#A8A298" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500">Native speed, WebAssembly portable</text>
 </svg>

--- a/website/scripts/build-assets.mjs
+++ b/website/scripts/build-assets.mjs
@@ -7,8 +7,8 @@ import { generateShowcaseManifest } from './showcase-manifest.mjs'
 // clone: the demo images the showcase/filter sections display, plus the manifest that
 // pages/index.tsx statically imports (a missing manifest 500s the page). Neither step
 // touches the network, so a flaky connection can't abort `vite dev` or the Playwright
-// e2e. The OG image (fetches a font from GitHub) and changelog refresh (GitHub releases
-// API) are intentionally excluded — dev's /changelog renders from the committed
+// e2e. The OG image (fetches the Inter font from Google Fonts) and changelog refresh
+// (GitHub releases API) are intentionally excluded — dev's /changelog renders from the committed
 // pages/changelog/index.md and og.png is only referenced as a <head> meta URL.
 export async function generateDevAssets() {
   await generateDemoImages()

--- a/website/scripts/og-image.mjs
+++ b/website/scripts/og-image.mjs
@@ -1,39 +1,68 @@
 import { promises as fs } from 'fs'
 
 import { createCanvas, GlobalFonts, Image } from '@napi-rs/canvas'
-import { pngQuantize } from '@napi-rs/image'
+import { losslessCompressPng } from '@napi-rs/image'
 
 const OG_WIDTH = 1200
 const OG_HEIGHT = 630
 const SVG_PATH = 'public/img/og.svg'
 
-// The OG SVG sets its text in Inter. resvg (inside @napi-rs/canvas) only renders
-// glyphs for fonts it can find, so register Inter before rasterizing. Google Fonts
-// hands back static .ttf URLs (resvg can't read .woff2) when asked with a legacy
-// user-agent; we resolve them fresh each build so the link can't go stale. If the
-// network is down the SVG falls back to its declared Arial/sans-serif stack, so a
-// flaky connection degrades the typeface instead of breaking the build.
-async function registerInter() {
-  if (GlobalFonts.families.some(({ family }) => family === 'Inter')) return
+// The OG SVG sets its text in the site's three faces — Space Grotesk (display),
+// Inter (body) and JetBrains Mono (labels/code). resvg (inside @napi-rs/canvas) only
+// renders glyphs for fonts it can find, so register them before rasterizing. Google
+// Fonts hands back static .ttf URLs (resvg can't read the repo's .woff2 builds) when
+// asked with a legacy user-agent; we resolve them fresh each build so the links can't
+// go stale. If the network is down each face falls back to the SVG's declared
+// Arial/sans-serif/monospace stack, so a flaky connection degrades the typeface
+// instead of breaking the build.
+const FONTS = [
+  { family: 'Space Grotesk', spec: 'Space+Grotesk:500,600,700' },
+  { family: 'Inter', spec: 'Inter:400,500,600,700' },
+  { family: 'JetBrains Mono', spec: 'JetBrains+Mono:400,500,600,700' },
+]
+
+// Google Fonts (and the gstatic CDN) occasionally drop the connection mid-handshake,
+// so retry a few times before giving up on a face.
+async function fetchRetry(url, init, tries = 4) {
+  let lastErr
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(url, init)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res
+    } catch (err) {
+      lastErr = err
+    }
+  }
+  throw lastErr
+}
+
+async function registerFont({ family, spec }) {
+  if (GlobalFonts.families.some((f) => f.family === family)) return
   try {
-    const css = await fetch('https://fonts.googleapis.com/css?family=Inter:400,500,600,700,800', {
+    const css = await fetchRetry(`https://fonts.googleapis.com/css?family=${spec}`, {
       headers: { 'User-Agent': 'Mozilla/4.0 (compatible)' },
       redirect: 'follow',
     }).then((res) => res.text())
     const urls = [...css.matchAll(/https:\/\/[^)]+\.ttf/g)].map((m) => m[0])
+    if (!urls.length) throw new Error('no .ttf urls in css')
     await Promise.all(
       urls.map(async (url) => {
-        const ttf = await fetch(url, { redirect: 'follow' }).then((res) => res.arrayBuffer())
-        GlobalFonts.register(Buffer.from(ttf), 'Inter')
+        const ttf = await fetchRetry(url, { redirect: 'follow' }).then((res) => res.arrayBuffer())
+        GlobalFonts.register(Buffer.from(ttf), family)
       }),
     )
   } catch (err) {
-    console.warn('[og-image] could not load Inter, falling back to system fonts:', err.message)
+    console.warn(`[og-image] could not load ${family}, falling back to system fonts:`, err.message)
   }
 }
 
+async function registerFonts() {
+  await Promise.all(FONTS.map(registerFont))
+}
+
 export async function generateOgImage() {
-  await registerInter()
+  await registerFonts()
 
   const svg = await fs.readFile(SVG_PATH)
   const image = new Image()
@@ -44,13 +73,9 @@ export async function generateOgImage() {
   ctx.drawImage(image, 0, 0, OG_WIDTH, OG_HEIGHT)
 
   await fs.mkdir('public/img', { recursive: true })
-  await fs.writeFile(
-    'public/img/og.png',
-    await pngQuantize(await canvas.encode('png'), {
-      maxQuality: 90,
-      minQuality: 75,
-    }),
-  )
+  // Lossless, not palette-quantized: the warm gradients band badly when reduced to
+  // 256 colors, and an OG image is fetched once by scrapers so size isn't critical.
+  await fs.writeFile('public/img/og.png', await losslessCompressPng(await canvas.encode('png')))
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) await generateOgImage()

--- a/website/scripts/og-image.mjs
+++ b/website/scripts/og-image.mjs
@@ -3,178 +3,47 @@ import { promises as fs } from 'fs'
 import { createCanvas, GlobalFonts, Image } from '@napi-rs/canvas'
 import { pngQuantize } from '@napi-rs/image'
 
-export async function generateOgImage() {
-  const canvas = createCanvas(1200, 700)
-  const ctx = canvas.getContext('2d')
+const OG_WIDTH = 1200
+const OG_HEIGHT = 630
+const SVG_PATH = 'public/img/og.svg'
 
-  ctx.globalCompositeOperation = 'destination-over'
-
-  const FONT_URL = `https://github.com/Brooooooklyn/canvas/raw/main/__test__/fonts/iosevka-slab-regular.ttf`
-
-  if (!GlobalFonts.families.some(({ family }) => family === 'Iosevka Slab')) {
-    const font = await fetch(FONT_URL, {
+// The OG SVG sets its text in Inter. resvg (inside @napi-rs/canvas) only renders
+// glyphs for fonts it can find, so register Inter before rasterizing. Google Fonts
+// hands back static .ttf URLs (resvg can't read .woff2) when asked with a legacy
+// user-agent; we resolve them fresh each build so the link can't go stale. If the
+// network is down the SVG falls back to its declared Arial/sans-serif stack, so a
+// flaky connection degrades the typeface instead of breaking the build.
+async function registerInter() {
+  if (GlobalFonts.families.some(({ family }) => family === 'Inter')) return
+  try {
+    const css = await fetch('https://fonts.googleapis.com/css?family=Inter:400,500,600,700,800', {
+      headers: { 'User-Agent': 'Mozilla/4.0 (compatible)' },
       redirect: 'follow',
-      follow: 10,
-    }).then((res) => res.arrayBuffer())
-    GlobalFonts.register(Buffer.from(font))
+    }).then((res) => res.text())
+    const urls = [...css.matchAll(/https:\/\/[^)]+\.ttf/g)].map((m) => m[0])
+    await Promise.all(
+      urls.map(async (url) => {
+        const ttf = await fetch(url, { redirect: 'follow' }).then((res) => res.arrayBuffer())
+        GlobalFonts.register(Buffer.from(ttf), 'Inter')
+      }),
+    )
+  } catch (err) {
+    console.warn('[og-image] could not load Inter, falling back to system fonts:', err.message)
   }
+}
 
-  ctx.fillStyle = 'white'
-  ctx.font = '48px Iosevka Slab'
-  const Title = '@napi-rs/image'
-  ctx.fillText(Title, 80, 100)
+export async function generateOgImage() {
+  await registerInter()
 
-  const Arrow = new Image()
-  Arrow.src = Buffer.from(`<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1088 615" version="1.1">
-  <g stroke-width="1" fill="none" fill-rule="evenodd">
-    <text font-family="Iosevka Slab" font-size="18" font-weight="600" fill="#00e676">
-      <tspan x="900" y="459">Optimized Images</tspan>
-    </text>
-    <g transform="translate(1002, 326)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-1"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="84" height="84" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="400" fill="#a7f3d0">
-        <tspan x="18.891" y="46.7096774">.png</tspan>
-      </text>
-    </g>
-    <g transform="translate(1002, 214)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-2"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="84" height="84" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#a7f3d0">
-        <tspan x="15" y="46.7096774">.avif</tspan>
-      </text>
-    </g>
-    <g transform="translate(894, 326)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-3"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="84" height="84" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#a7f3d0">
-        <tspan x="21.817" y="46.7096774">.jpg</tspan>
-      </text>
-    </g>
-    <g transform="translate(894, 214)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-4"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="84" height="84" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#a7f3d0">
-        <tspan x="9" y="46.7096774">.webp</tspan>
-      </text>
-    </g>
-    <g transform="translate(342, 225)" stroke="#73e8ff" stroke-width="4">
-      <path
-        d="M499.558824,86.52 C499.558824,86.52 484.852941,81.02 439.908088,109.436667 C394.963235,137.853333 380.992647,164.436667 380.992647,164.436667"
-        stroke-dasharray="7"></path>
-      <path
-        d="M499.558824,86.0616667 C499.558824,86.0616667 484.852941,91.5616667 439.908088,63.145 C394.963235,34.7283333 380.992647,8.145 380.992647,8.145"
-        stroke-dasharray="7"></path>
-      <path d="M0.477941176,170.395 C0.477941176,170.395 169.382939,98.895 447.847936,98.895" stroke-dasharray="6">
-      </path>
-      <path d="M0.477941176,72.395 C0.477941176,72.395 169.382939,0.895 447.847936,0.895" stroke-dasharray="6"
-        transform="translate(224.162939, 36.645000) scale(1, -1) translate(-224.162939, -36.645000) "></path>
-    </g>
-    <text font-family="Iosevka Slab" font-size="18" font-weight="600" fill="#ffcc80">
-      <tspan x="24.934" y="562">Raw Images</tspan>
-    </text>
-    <g transform="translate(228, 335)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-5"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.jpg</tspan>
-      </text>
-    </g>
-    <g transform="translate(228, 223)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-6"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.png</tspan>
-      </text>
-    </g>
-    <g transform="translate(116, 391)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-7"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.tiff</tspan>
-      </text>
-    </g>
-    <g transform="translate(116, 279)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-8"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.ico</tspan>
-      </text>
-    </g>
-    <g transform="translate(116, 167)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-9"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.pnm</tspan>
-      </text>
-    </g>
-    <g transform="translate(4, 447)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-10"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.bmp</tspan>
-      </text>
-    </g>
-    <g transform="translate(4, 335)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-11"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.tga</tspan>
-      </text>
-    </g>
-    <g transform="translate(4, 223)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-12"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.hdr</tspan>
-      </text>
-    </g>
-    <g transform="translate(4, 111)">
-      <g>
-        <use fill-opacity="0.1" fill="#b3e5fc" fill-rule="evenodd" xlink:href="#path-13"></use>
-        <rect stroke="#b3e5fc" stroke-width="4" x="-2" y="-2" width="66" height="66" rx="3"></rect>
-      </g>
-      <text font-family="Iosevka Slab" font-size="22" font-weight="500" fill="#fde68a">
-        <tspan x="10" y="38">.dxt</tspan>
-      </text>
-    </g>
-  </g>
-</svg>`)
-  ctx.drawImage(Arrow, 80, 60)
+  const svg = await fs.readFile(SVG_PATH)
+  const image = new Image()
+  image.src = svg
 
-  const ViceCityGradient = ctx.createLinearGradient(0, 0, 1200, 0)
-  ViceCityGradient.addColorStop(0, '#3494e6')
-  ViceCityGradient.addColorStop(1, '#EC6EAD')
-  ctx.fillStyle = ViceCityGradient
-  ctx.fillRect(0, 0, 1200, 700)
+  const canvas = createCanvas(OG_WIDTH, OG_HEIGHT)
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(image, 0, 0, OG_WIDTH, OG_HEIGHT)
 
   await fs.mkdir('public/img', { recursive: true })
-
   await fs.writeFile(
     'public/img/og.png',
     await pngQuantize(await canvas.encode('png'), {


### PR DESCRIPTION
Redesigns the Open Graph share image and commits its SVG source.

## What & why
The old OG card was a cool navy/cyan/purple/pink design with no mention of browser support, and was visually disconnected from the site's warm-dark + rust editorial design. This PR:

1. **Commits the SVG source** at `public/img/og.svg` (`og.png` stays generated + gitignored).
2. **Re-skins to the site design system** — warm near-black bg + rust accent, fonts Space Grotesk (display) / Inter (body) / JetBrains Mono (labels, chips, format nodes), rust eyebrow style.
3. **Surfaces browser / WASM** — headline now reads *"Image processing for Node.js & the browser"* with `& the browser` in the rust accent; subtitle *"One Rust pipeline · WebAssembly · no install"*; panel footer *"Native speed, WebAssembly portable"*.

## Generator changes (`scripts/og-image.mjs`)
- Rasterizes the committed `og.svg` via resvg (`@napi-rs/canvas`) at the standard **1200×630** (was a hardcoded in-memory SVG at 1200×700).
- Registers all three site faces from Google Fonts (legacy-UA TTF resolution; resvg can't read the repo's `.woff2`) **with retry** for gstatic TLS flakiness; falls back to the SVG's `Arial/sans-serif/monospace` stack if the network is down so a flaky connection degrades the typeface instead of breaking the build.
- Encodes **lossless** via `@napi-rs/image` — the previous palette quantizer banded the warm gradients.

## Verification
Rendered `og.png` locally and inspected: all three fonts load, gradients are clean (no banding), 1200×630.

🤖 Generated with [Claude Code](https://claude.com/claude-code)