### PR TITLE
perf(binding): runtime-dispatched 4-lane SIMD for the pngQuantize nearest-palette argmin

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,11 @@
 [target.i686-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+avx2"]
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-feature=+avx2"]
+# x86_64-unknown-linux-gnu intentionally has NO `target-feature=+avx2`. The pngQuantize
+# quantizer runtime-detects AVX2/SSE4.1 per host and falls back to scalar on pre-AVX2 CPUs
+# (packages/binding/src/quantize_simd.rs). A static `+avx2` here would make
+# `is_x86_feature_detected!("avx2")` fold to a compile-time `true` (std_detect short-circuits
+# on `cfg!(target_feature)`), defeating that runtime fallback and SIGILL-ing the distributed
+# binary on pre-AVX2 x86_64 hosts. Keep the SIMD floor OFF for distributed x86_64 builds.
 [target.x86_64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=-crt-static"]
 [target.aarch64-unknown-linux-gnu]

--- a/packages/binding/src/lib.rs
+++ b/packages/binding/src/lib.rs
@@ -17,6 +17,10 @@ mod lab;
 #[cfg(feature = "binding")]
 pub mod png;
 mod quantize;
+// Runtime-dispatched SIMD kernels for the quantizer's nearest-palette argmin. Not
+// behind `binding` (same as `quantize`/`lab`) so the `--no-default-features` bench
+// core links it. Pure integer math -> byte-identical to the scalar reference.
+mod quantize_simd;
 /// Quantizer core, re-exported solely for the `benches/` CodSpeed micro-benchmarks
 /// (`benches/quantize.rs`). These names are not part of the addon's public API and
 /// may change without notice; nothing in the shipped JS surface depends on them.

--- a/packages/binding/src/quantize.rs
+++ b/packages/binding/src/quantize.rs
@@ -18,6 +18,7 @@ use rgb::RGBA8;
 use crate::lab::{
   Lab, MAX_DELTA_E76_SQ, delta_e76_sq, linear_to_srgb8, rgb_to_lab, srgb_to_linear_f,
 };
+use crate::quantize_simd::{self, OpaqueKernel};
 
 /// Hard upper bound on an 8-bit indexed palette.
 const MAX_PALETTE: usize = 256;
@@ -323,6 +324,75 @@ fn pdist_lab(query_lab: Lab, query_a: u8, entry_lab: Lab, entry_a: u8) -> i64 {
 #[inline]
 fn palette_labs(palette: &[RGBA8]) -> Vec<Lab> {
   palette.iter().map(|p| rgb_to_lab(p.r, p.g, p.b)).collect()
+}
+
+/// Structure-of-Arrays palette Lab cache for the hot nearest-palette scan.
+///
+/// Built ONCE where the palette is fixed across many queries (remap, k-means
+/// assignment/objective). It carries two views of the same data:
+///
+/// * `labs` (AoS) + `alpha` feed the COLD general path: a translucent query or a
+///   palette with a reserved transparent slot still goes through the unchanged
+///   [`nearest_lab`] (full `pdist_lab` + dim/vanish penalties). Reusing `nearest_lab`
+///   verbatim keeps that rare path byte-identical with zero logic duplication.
+/// * `l` / `a` / `b` (SoA `i32`) feed the HOT opaque fast path: contiguous component
+///   arrays a SIMD kernel can vector-load. See [`crate::quantize_simd`].
+///
+/// `all_opaque` is set when every entry has `alpha == 255`. Combined with an opaque
+/// query (`qa == 255`), the perceptual distance collapses to plain squared CIE76 ΔE
+/// (`dl²+da²+db²` — `wa/510 == 1`, alpha term 0, both penalties 0), which is exactly
+/// what the opaque kernel computes; proven equal to [`nearest_lab`] by the test
+/// `opaque_fast_path_equals_general`.
+struct PaletteLabSoa {
+  labs: Vec<Lab>,
+  l: Vec<i32>,
+  a: Vec<i32>,
+  b: Vec<i32>,
+  alpha: Vec<u8>,
+  all_opaque: bool,
+}
+
+impl PaletteLabSoa {
+  /// Builds the cache from a palette. `labs` matches [`palette_labs`] exactly.
+  fn from_palette(palette: &[RGBA8]) -> Self {
+    let labs: Vec<Lab> = palette.iter().map(|p| rgb_to_lab(p.r, p.g, p.b)).collect();
+    let l = labs.iter().map(|x| x.l).collect();
+    let a = labs.iter().map(|x| x.a).collect();
+    let b = labs.iter().map(|x| x.b).collect();
+    let alpha: Vec<u8> = palette.iter().map(|p| p.a).collect();
+    let all_opaque = alpha.iter().all(|&av| av == 255);
+    Self {
+      labs,
+      l,
+      a,
+      b,
+      alpha,
+      all_opaque,
+    }
+  }
+
+  /// Index of the nearest palette entry to `qlab`/`qa` under the perceptual metric.
+  ///
+  /// Fast path (opaque palette + opaque query): the SIMD/scalar `opaque_argmin` of
+  /// `dl²+da²+db²`, byte-identical to the general path. Otherwise the unchanged
+  /// [`nearest_lab`] (cold; translucent / transparent-slot cases). `skip_transparent`
+  /// and `guard` matter only on the general path — on the fast path the palette has no
+  /// transparent slot and the dim/vanish penalties are identically zero.
+  #[inline]
+  fn nearest(
+    &self,
+    kernel: OpaqueKernel,
+    qlab: Lab,
+    qa: u8,
+    skip_transparent: bool,
+    guard: u8,
+  ) -> usize {
+    if self.all_opaque && qa == 255 {
+      quantize_simd::opaque_argmin(kernel, &self.l, &self.a, &self.b, [qlab.l, qlab.a, qlab.b])
+    } else {
+      nearest_lab(&self.labs, &self.alpha, qlab, qa, skip_transparent, guard)
+    }
+  }
 }
 
 /// A distinct color and how many source pixels carry it.
@@ -956,14 +1026,14 @@ fn nearest(palette: &[RGBA8], c: RGBA8) -> usize {
 /// `pdist`; the D² reseed weights (`count · pdist`) are bounded identically and
 /// already use `u128`.
 fn kmeans_objective(palette: &[RGBA8], entries: &[ColorCount]) -> u128 {
-  let labs = palette_labs(palette);
-  let alphas: Vec<u8> = palette.iter().map(|p| p.a).collect();
+  let soa = PaletteLabSoa::from_palette(palette);
+  let kernel = quantize_simd::detect();
   let mut obj: u128 = 0;
   for e in entries {
     let qlab = rgb_to_lab(e.color.r, e.color.g, e.color.b);
     // Clustering objective: guard disabled (`0`) so the keep-best metric is pure `pdist`.
-    let idx = nearest_lab(&labs, &alphas, qlab, e.color.a, e.color.a > 0, 0);
-    let d = pdist_lab(qlab, e.color.a, labs[idx], alphas[idx]).max(0) as u128;
+    let idx = soa.nearest(kernel, qlab, e.color.a, e.color.a > 0, 0);
+    let d = pdist_lab(qlab, e.color.a, soa.labs[idx], soa.alpha[idx]).max(0) as u128;
     obj += e.count as u128 * d;
   }
   obj
@@ -1014,11 +1084,14 @@ fn kmeans_refine(palette: &mut [RGBA8], entries: &[ColorCount], iters: u8) {
   let mut best: Vec<RGBA8> = palette.to_vec();
   let mut best_obj: u128 = kmeans_objective(palette, entries);
 
+  // Detect the opaque-scan kernel ONCE for the whole refine (cheap, but never per
+  // entry); the SoA is rebuilt each pass below because the centroids move.
+  let kernel = quantize_simd::detect();
+
   for _ in 0..iters {
-    // Cache the palette's Labs for this pass's assignment scan (perceptual
-    // nearest), rebuilt each pass because the centroids moved.
-    let pal_labs = palette_labs(palette);
-    let pal_alphas: Vec<u8> = palette.iter().map(|p| p.a).collect();
+    // Cache the palette's Labs (SoA) for this pass's assignment scan, rebuilt each
+    // pass because the centroids moved.
+    let soa = PaletteLabSoa::from_palette(palette);
 
     // Accumulators per cluster.
     let mut sr = vec![0u64; k];
@@ -1028,13 +1101,12 @@ fn kmeans_refine(palette: &mut [RGBA8], entries: &[ColorCount], iters: u8) {
     let mut wn = vec![0u64; k];
 
     for (ei, e) in entries.iter().enumerate() {
-      let idx = nearest_lab(
-        &pal_labs,
-        &pal_alphas,
+      // Clustering assignment: guard disabled so centroids/palette stay byte-identical.
+      let idx = soa.nearest(
+        kernel,
         entry_labs[ei],
         entry_alphas[ei],
         entry_alphas[ei] > 0,
-        // Clustering assignment: guard disabled so centroids/palette stay byte-identical.
         0,
       );
       let c = e.count;
@@ -1176,27 +1248,25 @@ fn kmeans_refine(palette: &mut [RGBA8], entries: &[ColorCount], iters: u8) {
 
 /// Nearest-color remap with a per-color memoization cache (no dithering).
 fn remap_nearest(px: &[RGBA8], palette: &[RGBA8], bits: u8) -> Vec<u8> {
-  // Palette Labs cached once; the per-color cache only computes `rgb_to_lab` for
-  // each DISTINCT canonical key once (perceptual assignment via `nearest_lab`).
-  let pal_labs = palette_labs(palette);
-  let pal_alphas: Vec<u8> = palette.iter().map(|p| p.a).collect();
+  // Palette Labs cached once (SoA); the per-color cache only computes `rgb_to_lab`
+  // for each DISTINCT canonical key once (perceptual assignment via the dispatched scan).
+  let soa = PaletteLabSoa::from_palette(palette);
+  let kernel = quantize_simd::detect();
   let mut cache: HashMap<RGBA8, u8> = HashMap::new();
   let mut indices = Vec::with_capacity(px.len());
   for &p in px {
     let key = canonical_key(p, bits);
     let idx = *cache.entry(key).or_insert_with(|| {
-      nearest_lab(
-        &pal_labs,
-        &pal_alphas,
+      // `key` IS the (posterized) source pixel, so its alpha is the source visibility:
+      // `skip_transparent = key.a > 0` (a visible key must not resolve to the transparent
+      // slot) and the FINAL-REMAP visibility guard is keyed on the same source alpha
+      // `key.a` (posterize never touches alpha) so a visible pixel cannot vanish onto a
+      // much-dimmer entry.
+      soa.nearest(
+        kernel,
         rgb_to_lab(key.r, key.g, key.b),
         key.a,
-        // `key` IS the (posterized) source pixel here, so its alpha is the source
-        // visibility; a visible source key must not resolve to the transparent slot.
         key.a > 0,
-        // FINAL REMAP: enable the visibility guard keyed on the source pixel's alpha so
-        // a visible pixel cannot be assigned to a much-dimmer entry and vanish. `key.a`
-        // is the (posterized) source alpha; posterize never touches alpha, so it equals
-        // the raw source alpha.
         key.a,
       ) as u8
     });
@@ -1441,12 +1511,12 @@ fn remap_dither(px: &[RGBA8], width: usize, height: usize, palette: &[RGBA8], bi
   if width == 0 || height == 0 {
     return indices;
   }
-  // Cache the palette Labs ONCE: the palette is fixed across every pixel, so
+  // Cache the palette Labs ONCE (SoA): the palette is fixed across every pixel, so
   // `rgb_to_lab` runs `palette.len()` times here, not once per pixel. The per-pixel
   // query Lab (for `want`) is still computed per pixel — `want` varies — but that is
   // a single `rgb_to_lab` per visible pixel (the residual stays on RGB `dist2`).
-  let pal_labs = palette_labs(palette);
-  let pal_alphas: Vec<u8> = palette.iter().map(|p| p.a).collect();
+  let soa = PaletteLabSoa::from_palette(palette);
+  let kernel = quantize_simd::detect();
   // Two error rows of (r, g, b, a) deltas in f32 for sub-unit accumulation.
   let mut cur = vec![[0f32; 4]; width];
   let mut next = vec![[0f32; 4]; width];
@@ -1505,15 +1575,14 @@ fn remap_dither(px: &[RGBA8], width: usize, height: usize, palette: &[RGBA8], bi
       // are `continue`d above — so this flag is always `true` in this call; passing it
       // explicitly documents the invariant and removes any dependence on alpha never
       // being posterized.
-      let idx = nearest_lab(
-        &pal_labs,
-        &pal_alphas,
+      // FINAL-REMAP visibility guard keyed on the RAW source alpha `px[base].a` — NOT
+      // the dither-adjusted `want.a`, which can drop below the source: a visible source
+      // pixel must not vanish onto a much-dimmer entry even when its `want.a` clamped low.
+      let idx = soa.nearest(
+        kernel,
         rgb_to_lab(want.r, want.g, want.b),
         want.a,
         px[base].a > 0,
-        // FINAL REMAP visibility guard, keyed on the RAW source alpha `px[base].a` — NOT
-        // the dither-adjusted `want.a`, which can drop below the source: a visible source
-        // pixel must not vanish onto a much-dimmer entry even when its `want.a` clamped low.
         px[base].a,
       );
       indices[base] = idx as u8;
@@ -1914,6 +1983,46 @@ pub fn quantize_rgba(
 #[cfg(test)]
 mod tests {
   use super::*;
+
+  /// The SoA opaque fast path (scalar kernel) must return the SAME index as the general
+  /// [`nearest_lab`] for any fully-opaque palette + opaque query, because the perceptual
+  /// metric provably collapses to `dl²+da²+db²` there (`wa/510 == 1`, alpha term 0, both
+  /// penalties 0). This is the equivalence the golden pins depend on; the per-ISA SIMD
+  /// phases extend it (`quantize_simd::tests`) by swapping the scalar kernel for each
+  /// intrinsic. Sweeps palette sizes 1..=80 to exercise short and long scans.
+  #[test]
+  fn opaque_fast_path_equals_general() {
+    let mut seed: u64 = 0x1234_5678_9abc_def0;
+    let mut next = || {
+      seed = seed
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+      (seed >> 33) as u32
+    };
+    for n in 1..=80usize {
+      let palette: Vec<RGBA8> = (0..n)
+        .map(|_| RGBA8 {
+          r: (next() & 0xff) as u8,
+          g: (next() & 0xff) as u8,
+          b: (next() & 0xff) as u8,
+          a: 255,
+        })
+        .collect();
+      let soa = PaletteLabSoa::from_palette(&palette);
+      assert!(soa.all_opaque, "constructed palette must be opaque");
+      for _ in 0..20 {
+        let (r, g, b) = (
+          (next() & 0xff) as u8,
+          (next() & 0xff) as u8,
+          (next() & 0xff) as u8,
+        );
+        let qlab = rgb_to_lab(r, g, b);
+        let fast = soa.nearest(OpaqueKernel::Scalar, qlab, 255, true, 255);
+        let general = nearest_lab(&soa.labs, &soa.alpha, qlab, 255, true, 255);
+        assert_eq!(fast, general, "n={n} q=({r},{g},{b})");
+      }
+    }
+  }
 
   fn cfg(max_colors: u16, dither: bool, kmeans: u8) -> QuantizeConfig {
     QuantizeConfig {

--- a/packages/binding/src/quantize.rs
+++ b/packages/binding/src/quantize.rs
@@ -2024,6 +2024,36 @@ mod tests {
     }
   }
 
+  /// NEON and forced-scalar must produce byte-identical quantizer output end to end. A
+  /// smooth opaque gradient with many distinct colors forces the lossy remap+dither path
+  /// where the opaque SIMD kernel runs. Proves the kernel is exact AND that the
+  /// `IMAGE_QUANTIZE_SCALAR` fallback path is wired correctly (never-panic / same bytes).
+  #[cfg(target_arch = "aarch64")]
+  #[test]
+  fn neon_matches_scalar_end_to_end() {
+    let (w, h) = (48usize, 48usize);
+    let mut px = Vec::with_capacity(w * h);
+    for y in 0..h {
+      for x in 0..w {
+        px.push(RGBA8 {
+          r: (x * 5) as u8,
+          g: (y * 5) as u8,
+          b: ((x + y) * 2) as u8,
+          a: 255,
+        });
+      }
+    }
+    let config = cfg(16, true, 5);
+    let neon =
+      quantize_simd::test_override::with(OpaqueKernel::Neon, || quantize_rgba(&px, w, h, &config));
+    let scalar = quantize_simd::test_override::with(OpaqueKernel::Scalar, || {
+      quantize_rgba(&px, w, h, &config)
+    });
+    assert_eq!(neon.indices, scalar.indices, "indices differ");
+    assert_eq!(neon.palette, scalar.palette, "palette differs");
+    assert_eq!(neon.quality, scalar.quality, "quality differs");
+  }
+
   fn cfg(max_colors: u16, dither: bool, kmeans: u8) -> QuantizeConfig {
     QuantizeConfig {
       max_colors,

--- a/packages/binding/src/quantize_simd.rs
+++ b/packages/binding/src/quantize_simd.rs
@@ -47,6 +47,10 @@ pub(crate) enum OpaqueKernel {
   /// Portable integer reference. Defines the byte-exact result every other kernel
   /// must reproduce. Always available on every target.
   Scalar,
+  /// NEON (aarch64) 4-wide i32 argmin. NEON is part of the AArch64 baseline, so it is
+  /// always present on aarch64 — no runtime probe, no host can lack it.
+  #[cfg(target_arch = "aarch64")]
+  Neon,
 }
 
 /// Selects the opaque-scan kernel for this host, honouring the `IMAGE_QUANTIZE_SCALAR`
@@ -72,7 +76,16 @@ pub(crate) fn detect() -> OpaqueKernel {
 /// branches. Kept separate from [`detect`] so the override / escape-hatch logic is shared.
 #[inline]
 fn detect_native() -> OpaqueKernel {
-  OpaqueKernel::Scalar
+  #[cfg(target_arch = "aarch64")]
+  {
+    // NEON is mandatory in the AArch64 baseline, so it is always present — no probe
+    // needed and no host can lack it.
+    OpaqueKernel::Neon
+  }
+  #[cfg(not(target_arch = "aarch64"))]
+  {
+    OpaqueKernel::Scalar
+  }
 }
 
 /// `true` when `IMAGE_QUANTIZE_SCALAR` is set to a truthy value (`1`/`true`/`yes`). Read
@@ -107,6 +120,8 @@ pub(crate) fn opaque_argmin(
   debug_assert!(!l.is_empty());
   match kernel {
     OpaqueKernel::Scalar => opaque_scan_scalar(l, a, b, q),
+    #[cfg(target_arch = "aarch64")]
+    OpaqueKernel::Neon => unsafe { opaque_scan_neon(l, a, b, q) },
   }
 }
 
@@ -129,6 +144,81 @@ fn opaque_scan_scalar(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usize {
     }
   }
   best
+}
+
+/// NEON (aarch64) implementation of [`opaque_argmin`]: 4-wide i32 argmin of
+/// `dl²+da²+db²`, bit-identical to [`opaque_scan_scalar`]. Each lane keeps the lowest
+/// index achieving its running min (strict `vcltq`); then a scalar reduction over the 4
+/// lanes followed by the `n % 4` tail reproduces the ascending lowest-index-wins
+/// tie-break. Every intermediate is ≤ `MAX_DELTA_E76_SQ` (= 669_160_034) < 2³¹, so the
+/// i32 lanes never overflow. SAFETY: only reachable via `detect`/`opaque_argmin` on
+/// aarch64, where NEON is guaranteed.
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn opaque_scan_neon(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usize {
+  use core::arch::aarch64::*;
+  unsafe {
+    let n = l.len();
+    let ql = vdupq_n_s32(q[0]);
+    let qa = vdupq_n_s32(q[1]);
+    let qb = vdupq_n_s32(q[2]);
+    let idx_arr = [0i32, 1, 2, 3];
+    let lane_idx = vld1q_s32(idx_arr.as_ptr());
+    let mut min_d = vdupq_n_s32(i32::MAX);
+    let mut min_i = vdupq_n_s32(i32::MAX);
+
+    let mut i = 0usize;
+    while i + 4 <= n {
+      let dl = vsubq_s32(ql, vld1q_s32(l.as_ptr().add(i)));
+      let da = vsubq_s32(qa, vld1q_s32(a.as_ptr().add(i)));
+      let db = vsubq_s32(qb, vld1q_s32(b.as_ptr().add(i)));
+      let d = vaddq_s32(
+        vaddq_s32(vmulq_s32(dl, dl), vmulq_s32(da, da)),
+        vmulq_s32(db, db),
+      );
+      let cur_i = vaddq_s32(vdupq_n_s32(i as i32), lane_idx);
+      // lanes where d < min_d (STRICT: a later equal value does NOT replace -> lowest
+      // index kept within the lane, matching the scalar `<`).
+      let mask = vcltq_s32(d, min_d);
+      min_d = vbslq_s32(mask, d, min_d);
+      min_i = vbslq_s32(mask, cur_i, min_i);
+      i += 4;
+    }
+
+    // Reduce the 4 lanes: lowest d, tie -> lowest index.
+    let mut ld = [0i32; 4];
+    let mut li = [0i32; 4];
+    vst1q_s32(ld.as_mut_ptr(), min_d);
+    vst1q_s32(li.as_mut_ptr(), min_i);
+
+    let mut best_d = i64::MAX;
+    let mut best = 0usize;
+    for (&d_lane, &i_lane) in ld.iter().zip(li.iter()) {
+      if i_lane == i32::MAX {
+        continue; // lane saw no full block (n < 4)
+      }
+      let d = d_lane as i64;
+      let idx = i_lane as usize;
+      if d < best_d || (d == best_d && idx < best) {
+        best_d = d;
+        best = idx;
+      }
+    }
+    // Tail (n % 4): ascending, strict `<`, so a tail entry only wins on a STRICT
+    // improvement — preserving lowest-index-on-tie against the lower-indexed lane winners.
+    while i < n {
+      let dl = (q[0] - l[i]) as i64;
+      let da = (q[1] - a[i]) as i64;
+      let db = (q[2] - b[i]) as i64;
+      let d = dl * dl + da * da + db * db;
+      if d < best_d {
+        best_d = d;
+        best = i;
+      }
+      i += 1;
+    }
+    best
+  }
 }
 
 /// Test-only thread-local kernel override, so a single test process can run the same
@@ -241,5 +331,11 @@ mod tests {
     assert_kernel_matches_scalar("dispatch-scalar", |l, a, b, q| {
       opaque_argmin(OpaqueKernel::Scalar, l, a, b, q)
     });
+  }
+
+  #[cfg(target_arch = "aarch64")]
+  #[test]
+  fn kernel_matches_scalar_neon() {
+    assert_kernel_matches_scalar("neon", |l, a, b, q| unsafe { opaque_scan_neon(l, a, b, q) });
   }
 }

--- a/packages/binding/src/quantize_simd.rs
+++ b/packages/binding/src/quantize_simd.rs
@@ -12,11 +12,12 @@
 //! d == de == dl² + da² + db²        (dl,da,db = query.Lab − entry.Lab, in ×100 units)
 //! ```
 //!
-//! with `de ≤ MAX_DELTA_E76_SQ = 669_160_034 < 2³¹`, so the whole scan fits in **i32
-//! lanes** — no divide, no 64-bit, no penalties, no branches. This module provides an
-//! `i32` argmin over Structure-of-Arrays palette Lab components (`l[]`, `a[]`, `b[]`),
-//! dispatched at runtime to the widest SIMD the host actually supports, with a scalar
-//! reference that defines the result.
+//! For in-gamut Lab this is `de ≤ MAX_DELTA_E76_SQ = 669_160_034`; even an out-of-gamut
+//! k-means centroid keeps each `|Δ| ≤ ~26_000`, so `dl²+da²+db² ≤ 3·26000² ≈ 2.03e9 <
+//! i32::MAX`. The whole scan therefore fits in **i32 lanes** — no divide, no 64-bit, no
+//! penalties, no branches. This module provides an `i32` argmin over Structure-of-Arrays
+//! palette Lab components (`l[]`, `a[]`, `b[]`), dispatched at runtime to a 128-bit 4-lane
+//! SIMD kernel on every supported arch, with a scalar reference that defines the result.
 //!
 //! # Determinism is SACRED
 //!
@@ -51,6 +52,12 @@ pub(crate) enum OpaqueKernel {
   /// always present on aarch64 — no runtime probe, no host can lack it.
   #[cfg(target_arch = "aarch64")]
   Neon,
+  /// SSE4.1 (x86_64) 4-wide i32 argmin — the 128-bit 4-lane path, uniform with
+  /// NEON/simd128. Selected when the host reports SSE4.1; older x86 falls back to scalar.
+  /// AVX2's extra width is intentionally unused so every platform runs the identical
+  /// 4-lane reduction (one structure to audit for the byte-identical cross-platform contract).
+  #[cfg(target_arch = "x86_64")]
+  Sse41,
 }
 
 /// Selects the opaque-scan kernel for this host, honouring the `IMAGE_QUANTIZE_SCALAR`
@@ -71,9 +78,8 @@ pub(crate) fn detect() -> OpaqueKernel {
   detect_native()
 }
 
-/// Runtime feature probe, per architecture. Phase 0 has no SIMD variants yet, so every
-/// arch resolves to [`OpaqueKernel::Scalar`]; later phases fill in the `is_*_detected`
-/// branches. Kept separate from [`detect`] so the override / escape-hatch logic is shared.
+/// Runtime feature probe, per architecture. Kept separate from [`detect`] so the override
+/// / escape-hatch logic is shared.
 #[inline]
 fn detect_native() -> OpaqueKernel {
   #[cfg(target_arch = "aarch64")]
@@ -82,7 +88,18 @@ fn detect_native() -> OpaqueKernel {
     // needed and no host can lack it.
     OpaqueKernel::Neon
   }
-  #[cfg(not(target_arch = "aarch64"))]
+  #[cfg(target_arch = "x86_64")]
+  {
+    // Probe at runtime so a pre-SSE4.1 x86 host never executes an unsupported
+    // instruction — it falls back to scalar. SSE4.1 is the 4-lane 128-bit path; AVX2's
+    // extra width is intentionally unused so every platform runs the identical reduction.
+    if std::is_x86_feature_detected!("sse4.1") {
+      OpaqueKernel::Sse41
+    } else {
+      OpaqueKernel::Scalar
+    }
+  }
+  #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
   {
     OpaqueKernel::Scalar
   }
@@ -122,6 +139,8 @@ pub(crate) fn opaque_argmin(
     OpaqueKernel::Scalar => opaque_scan_scalar(l, a, b, q),
     #[cfg(target_arch = "aarch64")]
     OpaqueKernel::Neon => unsafe { opaque_scan_neon(l, a, b, q) },
+    #[cfg(target_arch = "x86_64")]
+    OpaqueKernel::Sse41 => unsafe { opaque_scan_sse41(l, a, b, q) },
   }
 }
 
@@ -150,8 +169,9 @@ fn opaque_scan_scalar(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usize {
 /// `dl²+da²+db²`, bit-identical to [`opaque_scan_scalar`]. Each lane keeps the lowest
 /// index achieving its running min (strict `vcltq`); then a scalar reduction over the 4
 /// lanes followed by the `n % 4` tail reproduces the ascending lowest-index-wins
-/// tie-break. Every intermediate is ≤ `MAX_DELTA_E76_SQ` (= 669_160_034) < 2³¹, so the
-/// i32 lanes never overflow. SAFETY: only reachable via `detect`/`opaque_argmin` on
+/// tie-break. Every intermediate stays < i32::MAX (in-gamut `de ≤ MAX_DELTA_E76_SQ =
+/// 669_160_034`; even an out-of-gamut `|Δ| ≤ ~26_000` gives `dl²+da²+db² ≈ 2.03e9 < 2³¹`),
+/// so the i32 lanes never overflow. SAFETY: only reachable via `detect`/`opaque_argmin` on
 /// aarch64, where NEON is guaranteed.
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
@@ -206,6 +226,80 @@ unsafe fn opaque_scan_neon(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usiz
     }
     // Tail (n % 4): ascending, strict `<`, so a tail entry only wins on a STRICT
     // improvement — preserving lowest-index-on-tie against the lower-indexed lane winners.
+    while i < n {
+      let dl = (q[0] - l[i]) as i64;
+      let da = (q[1] - a[i]) as i64;
+      let db = (q[2] - b[i]) as i64;
+      let d = dl * dl + da * da + db * db;
+      if d < best_d {
+        best_d = d;
+        best = i;
+      }
+      i += 1;
+    }
+    best
+  }
+}
+
+/// SSE4.1 (x86_64) implementation of [`opaque_argmin`]: 4-wide i32 argmin of `dl²+da²+db²`,
+/// the 128-bit path uniform with NEON/simd128 (AVX2's extra width is intentionally unused so
+/// every arch runs the identical 4-lane reduction). Bit-identical to [`opaque_scan_scalar`]:
+/// strict per-lane compare (`_mm_cmplt_epi32`) keeps the lowest index within a lane, then a
+/// lowest-index cross-lane reduction + the `n % 4` scalar tail reproduce the ascending
+/// tie-break. Every intermediate stays < i32::MAX (in-gamut `de ≤ MAX_DELTA_E76_SQ =
+/// 669_160_034`; even an out-of-gamut `|Δ| ≤ ~26_000` gives `dl²+da²+db² ≈ 2.03e9 < 2³¹`), so
+/// the i32 lanes never overflow. SAFETY: only reachable via `detect`/`opaque_argmin` after
+/// `is_x86_feature_detected!("sse4.1")`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "sse4.1")]
+unsafe fn opaque_scan_sse41(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usize {
+  use core::arch::x86_64::*;
+  unsafe {
+    let n = l.len();
+    let ql = _mm_set1_epi32(q[0]);
+    let qa = _mm_set1_epi32(q[1]);
+    let qb = _mm_set1_epi32(q[2]);
+    let lane_idx = _mm_setr_epi32(0, 1, 2, 3);
+    let mut min_d = _mm_set1_epi32(i32::MAX);
+    let mut min_i = _mm_set1_epi32(i32::MAX);
+
+    let mut i = 0usize;
+    while i + 4 <= n {
+      let lv = _mm_loadu_si128(l.as_ptr().add(i) as *const __m128i);
+      let av = _mm_loadu_si128(a.as_ptr().add(i) as *const __m128i);
+      let bv = _mm_loadu_si128(b.as_ptr().add(i) as *const __m128i);
+      let dl = _mm_sub_epi32(ql, lv);
+      let da = _mm_sub_epi32(qa, av);
+      let db = _mm_sub_epi32(qb, bv);
+      let d = _mm_add_epi32(
+        _mm_add_epi32(_mm_mullo_epi32(dl, dl), _mm_mullo_epi32(da, da)),
+        _mm_mullo_epi32(db, db),
+      );
+      let cur_i = _mm_add_epi32(_mm_set1_epi32(i as i32), lane_idx);
+      let mask = _mm_cmplt_epi32(d, min_d); // d < min_d, STRICT (SSE2)
+      min_d = _mm_blendv_epi8(min_d, d, mask);
+      min_i = _mm_blendv_epi8(min_i, cur_i, mask);
+      i += 4;
+    }
+
+    let mut ld = [0i32; 4];
+    let mut li = [0i32; 4];
+    _mm_storeu_si128(ld.as_mut_ptr() as *mut __m128i, min_d);
+    _mm_storeu_si128(li.as_mut_ptr() as *mut __m128i, min_i);
+
+    let mut best_d = i64::MAX;
+    let mut best = 0usize;
+    for (&d_lane, &i_lane) in ld.iter().zip(li.iter()) {
+      if i_lane == i32::MAX {
+        continue;
+      }
+      let d = d_lane as i64;
+      let idx = i_lane as usize;
+      if d < best_d || (d == best_d && idx < best) {
+        best_d = d;
+        best = idx;
+      }
+    }
     while i < n {
       let dl = (q[0] - l[i]) as i64;
       let da = (q[1] - a[i]) as i64;
@@ -337,5 +431,16 @@ mod tests {
   #[test]
   fn kernel_matches_scalar_neon() {
     assert_kernel_matches_scalar("neon", |l, a, b, q| unsafe { opaque_scan_neon(l, a, b, q) });
+  }
+
+  #[cfg(target_arch = "x86_64")]
+  #[test]
+  fn kernel_matches_scalar_sse41() {
+    if !std::is_x86_feature_detected!("sse4.1") {
+      return; // host (or Rosetta) without SSE4.1: skip; x86 CI covers it
+    }
+    assert_kernel_matches_scalar("sse41", |l, a, b, q| unsafe {
+      opaque_scan_sse41(l, a, b, q)
+    });
   }
 }

--- a/packages/binding/src/quantize_simd.rs
+++ b/packages/binding/src/quantize_simd.rs
@@ -58,6 +58,11 @@ pub(crate) enum OpaqueKernel {
   /// 4-lane reduction (one structure to audit for the byte-identical cross-platform contract).
   #[cfg(target_arch = "x86_64")]
   Sse41,
+  /// wasm32 `simd128` 4-wide i32 argmin — the 128-bit 4-lane path, uniform with NEON/SSE4.1.
+  /// simd128 is a COMPILE-TIME feature on wasm (no runtime detection exists); the build
+  /// enables it via `.cargo/config.toml` (`+simd128`). A wasm build without it uses scalar.
+  #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+  Simd128,
 }
 
 /// Selects the opaque-scan kernel for this host, honouring the `IMAGE_QUANTIZE_SCALAR`
@@ -99,7 +104,24 @@ fn detect_native() -> OpaqueKernel {
       OpaqueKernel::Scalar
     }
   }
-  #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+  #[cfg(target_arch = "wasm32")]
+  {
+    // simd128 is compile-time on wasm — no runtime probe. Present (build sets +simd128) ->
+    // Simd128; absent -> scalar. Either way, never an illegal instruction.
+    #[cfg(target_feature = "simd128")]
+    {
+      OpaqueKernel::Simd128
+    }
+    #[cfg(not(target_feature = "simd128"))]
+    {
+      OpaqueKernel::Scalar
+    }
+  }
+  #[cfg(not(any(
+    target_arch = "aarch64",
+    target_arch = "x86_64",
+    target_arch = "wasm32"
+  )))]
   {
     OpaqueKernel::Scalar
   }
@@ -141,6 +163,8 @@ pub(crate) fn opaque_argmin(
     OpaqueKernel::Neon => unsafe { opaque_scan_neon(l, a, b, q) },
     #[cfg(target_arch = "x86_64")]
     OpaqueKernel::Sse41 => unsafe { opaque_scan_sse41(l, a, b, q) },
+    #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+    OpaqueKernel::Simd128 => unsafe { opaque_scan_simd128(l, a, b, q) },
   }
 }
 
@@ -315,6 +339,81 @@ unsafe fn opaque_scan_sse41(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usi
   }
 }
 
+/// wasm32 `simd128` implementation of [`opaque_argmin`]: 4-wide i32 argmin of `dl²+da²+db²`,
+/// the 128-bit path uniform with NEON/SSE4.1. Bit-identical to [`opaque_scan_scalar`]: strict
+/// per-lane compare (`i32x4_lt`) keeps the lowest index within a lane, then a lowest-index
+/// cross-lane reduction + the `n % 4` scalar tail reproduce the ascending tie-break. Every
+/// intermediate stays < i32::MAX (in-gamut `de ≤ MAX_DELTA_E76_SQ = 669_160_034`; even an
+/// out-of-gamut `|Δ| ≤ ~26_000` gives `dl²+da²+db² ≈ 2.03e9 < 2³¹`), so the i32 lanes never
+/// overflow. SAFETY: only compiled/reached when `simd128` is statically enabled (gated by
+/// `cfg(target_feature = "simd128")`), so the ops are always legal.
+#[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+#[target_feature(enable = "simd128")]
+unsafe fn opaque_scan_simd128(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usize {
+  use core::arch::wasm32::*;
+  unsafe {
+    let n = l.len();
+    let ql = i32x4_splat(q[0]);
+    let qa = i32x4_splat(q[1]);
+    let qb = i32x4_splat(q[2]);
+    let lane_idx = i32x4(0, 1, 2, 3);
+    let mut min_d = i32x4_splat(i32::MAX);
+    let mut min_i = i32x4_splat(i32::MAX);
+
+    let mut i = 0usize;
+    while i + 4 <= n {
+      let lv = v128_load(l.as_ptr().add(i) as *const v128);
+      let av = v128_load(a.as_ptr().add(i) as *const v128);
+      let bv = v128_load(b.as_ptr().add(i) as *const v128);
+      let dl = i32x4_sub(ql, lv);
+      let da = i32x4_sub(qa, av);
+      let db = i32x4_sub(qb, bv);
+      let d = i32x4_add(
+        i32x4_add(i32x4_mul(dl, dl), i32x4_mul(da, da)),
+        i32x4_mul(db, db),
+      );
+      let cur_i = i32x4_add(i32x4_splat(i as i32), lane_idx);
+      // lanes where d < min_d, STRICT signed compare. bitselect(a,b,mask): mask lane all-ones
+      // -> pick a. So pick d/cur_i exactly where d < min_d -> lowest index kept within lane.
+      let mask = i32x4_lt(d, min_d);
+      min_d = v128_bitselect(d, min_d, mask);
+      min_i = v128_bitselect(cur_i, min_i, mask);
+      i += 4;
+    }
+
+    let mut ld = [0i32; 4];
+    let mut li = [0i32; 4];
+    v128_store(ld.as_mut_ptr() as *mut v128, min_d);
+    v128_store(li.as_mut_ptr() as *mut v128, min_i);
+
+    let mut best_d = i64::MAX;
+    let mut best = 0usize;
+    for (&d_lane, &i_lane) in ld.iter().zip(li.iter()) {
+      if i_lane == i32::MAX {
+        continue;
+      }
+      let d = d_lane as i64;
+      let idx = i_lane as usize;
+      if d < best_d || (d == best_d && idx < best) {
+        best_d = d;
+        best = idx;
+      }
+    }
+    while i < n {
+      let dl = (q[0] - l[i]) as i64;
+      let da = (q[1] - a[i]) as i64;
+      let db = (q[2] - b[i]) as i64;
+      let d = dl * dl + da * da + db * db;
+      if d < best_d {
+        best_d = d;
+        best = i;
+      }
+      i += 1;
+    }
+    best
+  }
+}
+
 /// Test-only thread-local kernel override, so a single test process can run the same
 /// quantize twice — once on the detected SIMD kernel, once forced to scalar — and assert
 /// byte-identical output. Thread-local (not a global) so parallel tests don't race.
@@ -441,6 +540,14 @@ mod tests {
     }
     assert_kernel_matches_scalar("sse41", |l, a, b, q| unsafe {
       opaque_scan_sse41(l, a, b, q)
+    });
+  }
+
+  #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
+  #[test]
+  fn kernel_matches_scalar_simd128() {
+    assert_kernel_matches_scalar("simd128", |l, a, b, q| unsafe {
+      opaque_scan_simd128(l, a, b, q)
     });
   }
 }

--- a/packages/binding/src/quantize_simd.rs
+++ b/packages/binding/src/quantize_simd.rs
@@ -16,8 +16,9 @@
 //! k-means centroid keeps each `|Δ| ≤ ~26_000`, so `dl²+da²+db² ≤ 3·26000² ≈ 2.03e9 <
 //! i32::MAX`. The whole scan therefore fits in **i32 lanes** — no divide, no 64-bit, no
 //! penalties, no branches. This module provides an `i32` argmin over Structure-of-Arrays
-//! palette Lab components (`l[]`, `a[]`, `b[]`), dispatched at runtime to a 128-bit 4-lane
-//! SIMD kernel on every supported arch, with a scalar reference that defines the result.
+//! palette Lab components (`l[]`, `a[]`, `b[]`), dispatched at runtime to the widest SIMD the
+//! host supports (AVX2 8-wide or SSE4.1 4-wide on x86; NEON 4-wide on aarch64; simd128 4-wide
+//! on wasm), with a scalar reference that defines the result every width reproduces.
 //!
 //! # Determinism is SACRED
 //!
@@ -33,9 +34,14 @@
 //! Each `*_simd` kernel is an `unsafe fn` marked `#[target_feature(enable = …)]`; it is
 //! ONLY ever reached through [`detect`], which gates on `is_*_feature_detected!` (x86) or
 //! a guaranteed-baseline arch (`neon` on aarch64, `simd128` compiled-in on wasm). A host
-//! lacking the feature takes the scalar path, so no illegal instruction can execute. The
-//! `IMAGE_QUANTIZE_SCALAR=1` escape hatch (and the test-only thread-local override) force
-//! the scalar path on a SIMD-capable host to prove the fallback.
+//! lacking the feature takes the scalar path, so no illegal instruction can execute — but on
+//! x86 this holds ONLY because the distributed builds are not compiled with a static
+//! `+avx2`/`+sse4.1` floor: `is_x86_feature_detected!` short-circuits on
+//! `cfg!(target_feature)` (std_detect), so a static floor would fold the probe to a
+//! compile-time `true` and run the kernel unconditionally — SIGILL on a host that lacks it.
+//! Keep those floors out of `.cargo/config.toml` for distributed x86_64 targets (see the note
+//! there). The `IMAGE_QUANTIZE_SCALAR=1` escape hatch (and the test-only thread-local
+//! override) force the scalar path on a SIMD-capable host to prove the fallback.
 
 use std::sync::OnceLock;
 
@@ -52,10 +58,17 @@ pub(crate) enum OpaqueKernel {
   /// always present on aarch64 — no runtime probe, no host can lack it.
   #[cfg(target_arch = "aarch64")]
   Neon,
-  /// SSE4.1 (x86_64) 4-wide i32 argmin — the 128-bit 4-lane path, uniform with
-  /// NEON/simd128. Selected when the host reports SSE4.1; older x86 falls back to scalar.
-  /// AVX2's extra width is intentionally unused so every platform runs the identical
-  /// 4-lane reduction (one structure to audit for the byte-identical cross-platform contract).
+  /// AVX2 (x86_64) 8-wide i32 argmin — the widest x86 path, preferred when the host reports
+  /// AVX2 (the common case on modern x86 and the CodSpeed runner). Wider lanes than the 4-wide
+  /// kernels, but byte-identical: integer add/mul/min are exact, so the 8-lane reduction
+  /// reaches the same lowest-index argmin as scalar (the `kernel_matches_scalar_*` tests gate
+  /// every width against the scalar reference).
+  #[cfg(target_arch = "x86_64")]
+  Avx2,
+  /// SSE4.1 (x86_64) 4-wide i32 argmin — the pre-AVX2 x86 fallback (older Intel Macs, some
+  /// musl/Windows hosts). Selected when the host reports SSE4.1 but not AVX2; older x86 still
+  /// falls back to scalar. Produces the identical argmin as AVX2/scalar — different lane width,
+  /// same exact-integer result, so the byte-identical cross-arch contract holds across widths.
   #[cfg(target_arch = "x86_64")]
   Sse41,
   /// wasm32 `simd128` 4-wide i32 argmin — the 128-bit 4-lane path, uniform with NEON/SSE4.1.
@@ -95,10 +108,12 @@ fn detect_native() -> OpaqueKernel {
   }
   #[cfg(target_arch = "x86_64")]
   {
-    // Probe at runtime so a pre-SSE4.1 x86 host never executes an unsupported
-    // instruction — it falls back to scalar. SSE4.1 is the 4-lane 128-bit path; AVX2's
-    // extra width is intentionally unused so every platform runs the identical reduction.
-    if std::is_x86_feature_detected!("sse4.1") {
+    // Probe at runtime, preferring the widest path the host supports so no host ever
+    // executes an unsupported instruction: AVX2 (8-wide) on modern x86, SSE4.1 (4-wide)
+    // on pre-AVX2 x86, scalar on anything older. All three reach the byte-identical argmin.
+    if std::is_x86_feature_detected!("avx2") {
+      OpaqueKernel::Avx2
+    } else if std::is_x86_feature_detected!("sse4.1") {
       OpaqueKernel::Sse41
     } else {
       OpaqueKernel::Scalar
@@ -161,6 +176,8 @@ pub(crate) fn opaque_argmin(
     OpaqueKernel::Scalar => opaque_scan_scalar(l, a, b, q),
     #[cfg(target_arch = "aarch64")]
     OpaqueKernel::Neon => unsafe { opaque_scan_neon(l, a, b, q) },
+    #[cfg(target_arch = "x86_64")]
+    OpaqueKernel::Avx2 => unsafe { opaque_scan_avx2(l, a, b, q) },
     #[cfg(target_arch = "x86_64")]
     OpaqueKernel::Sse41 => unsafe { opaque_scan_sse41(l, a, b, q) },
     #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
@@ -265,9 +282,84 @@ unsafe fn opaque_scan_neon(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usiz
   }
 }
 
+/// AVX2 (x86_64) implementation of [`opaque_argmin`]: 8-wide i32 argmin of `dl²+da²+db²`, the
+/// widest x86 path. Bit-identical to [`opaque_scan_scalar`] and to the 4-wide kernels: the
+/// per-lane compare is STRICT (`_mm256_cmpgt_epi32(min_d, d)` is `d < min_d`), so a later equal
+/// value never displaces the lower index within a lane; an 8-lane lowest-index cross-lane
+/// reduction + the `n % 8` scalar tail reproduce the scalar reference's ascending
+/// lowest-index-wins tie-break. Every intermediate stays < i32::MAX (in-gamut
+/// `de ≤ MAX_DELTA_E76_SQ = 669_160_034`; even an out-of-gamut `|Δ| ≤ ~26_000` gives
+/// `dl²+da²+db² ≈ 2.03e9 < 2³¹`), so the i32 lanes never overflow. SAFETY: only reachable via
+/// `detect`/`opaque_argmin` after `is_x86_feature_detected!("avx2")`.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn opaque_scan_avx2(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usize {
+  use core::arch::x86_64::*;
+  unsafe {
+    let n = l.len();
+    let ql = _mm256_set1_epi32(q[0]);
+    let qa = _mm256_set1_epi32(q[1]);
+    let qb = _mm256_set1_epi32(q[2]);
+    let lane_idx = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
+    let mut min_d = _mm256_set1_epi32(i32::MAX);
+    let mut min_i = _mm256_set1_epi32(i32::MAX);
+
+    let mut i = 0usize;
+    while i + 8 <= n {
+      let lv = _mm256_loadu_si256(l.as_ptr().add(i) as *const __m256i);
+      let av = _mm256_loadu_si256(a.as_ptr().add(i) as *const __m256i);
+      let bv = _mm256_loadu_si256(b.as_ptr().add(i) as *const __m256i);
+      let dl = _mm256_sub_epi32(ql, lv);
+      let da = _mm256_sub_epi32(qa, av);
+      let db = _mm256_sub_epi32(qb, bv);
+      let d = _mm256_add_epi32(
+        _mm256_add_epi32(_mm256_mullo_epi32(dl, dl), _mm256_mullo_epi32(da, da)),
+        _mm256_mullo_epi32(db, db),
+      );
+      let cur_i = _mm256_add_epi32(_mm256_set1_epi32(i as i32), lane_idx);
+      // lanes where d < min_d: cmpgt(min_d, d) == (min_d > d) == (d < min_d), STRICT.
+      let mask = _mm256_cmpgt_epi32(min_d, d);
+      min_d = _mm256_blendv_epi8(min_d, d, mask);
+      min_i = _mm256_blendv_epi8(min_i, cur_i, mask);
+      i += 8;
+    }
+
+    let mut ld = [0i32; 8];
+    let mut li = [0i32; 8];
+    _mm256_storeu_si256(ld.as_mut_ptr() as *mut __m256i, min_d);
+    _mm256_storeu_si256(li.as_mut_ptr() as *mut __m256i, min_i);
+
+    let mut best_d = i64::MAX;
+    let mut best = 0usize;
+    for (&d_lane, &i_lane) in ld.iter().zip(li.iter()) {
+      if i_lane == i32::MAX {
+        continue;
+      }
+      let d = d_lane as i64;
+      let idx = i_lane as usize;
+      if d < best_d || (d == best_d && idx < best) {
+        best_d = d;
+        best = idx;
+      }
+    }
+    while i < n {
+      let dl = (q[0] - l[i]) as i64;
+      let da = (q[1] - a[i]) as i64;
+      let db = (q[2] - b[i]) as i64;
+      let d = dl * dl + da * da + db * db;
+      if d < best_d {
+        best_d = d;
+        best = i;
+      }
+      i += 1;
+    }
+    best
+  }
+}
+
 /// SSE4.1 (x86_64) implementation of [`opaque_argmin`]: 4-wide i32 argmin of `dl²+da²+db²`,
-/// the 128-bit path uniform with NEON/simd128 (AVX2's extra width is intentionally unused so
-/// every arch runs the identical 4-lane reduction). Bit-identical to [`opaque_scan_scalar`]:
+/// the pre-AVX2 x86 fallback (older Intel Macs, some musl/Windows hosts). Bit-identical to
+/// [`opaque_scan_scalar`] and to AVX2 — same exact-integer argmin, narrower lanes:
 /// strict per-lane compare (`_mm_cmplt_epi32`) keeps the lowest index within a lane, then a
 /// lowest-index cross-lane reduction + the `n % 4` scalar tail reproduce the ascending
 /// tie-break. Every intermediate stays < i32::MAX (in-gamut `de ≤ MAX_DELTA_E76_SQ =
@@ -530,6 +622,15 @@ mod tests {
   #[test]
   fn kernel_matches_scalar_neon() {
     assert_kernel_matches_scalar("neon", |l, a, b, q| unsafe { opaque_scan_neon(l, a, b, q) });
+  }
+
+  #[cfg(target_arch = "x86_64")]
+  #[test]
+  fn kernel_matches_scalar_avx2() {
+    if !std::is_x86_feature_detected!("avx2") {
+      return; // host (or Rosetta) without AVX2: skip; real-AVX2 x86 (CI / qemu) covers it
+    }
+    assert_kernel_matches_scalar("avx2", |l, a, b, q| unsafe { opaque_scan_avx2(l, a, b, q) });
   }
 
   #[cfg(target_arch = "x86_64")]

--- a/packages/binding/src/quantize_simd.rs
+++ b/packages/binding/src/quantize_simd.rs
@@ -1,0 +1,245 @@
+//! Runtime-dispatched SIMD kernels for the quantizer's hottest inner loop: the
+//! per-pixel **nearest-palette argmin** in `remap_dither` (and the remap / k-means
+//! assignment scans).
+//!
+//! # What this accelerates
+//!
+//! For a fully-opaque palette and an opaque query the perceptual distance
+//! `nearest_lab` minimizes collapses (proven in `quantize.rs`) to exactly the
+//! squared CIE76 ΔE:
+//!
+//! ```text
+//! d == de == dl² + da² + db²        (dl,da,db = query.Lab − entry.Lab, in ×100 units)
+//! ```
+//!
+//! with `de ≤ MAX_DELTA_E76_SQ = 669_160_034 < 2³¹`, so the whole scan fits in **i32
+//! lanes** — no divide, no 64-bit, no penalties, no branches. This module provides an
+//! `i32` argmin over Structure-of-Arrays palette Lab components (`l[]`, `a[]`, `b[]`),
+//! dispatched at runtime to the widest SIMD the host actually supports, with a scalar
+//! reference that defines the result.
+//!
+//! # Determinism is SACRED
+//!
+//! The encoded PNG must stay **byte-identical** across x86_64 / aarch64 / wasm32 and
+//! run-to-run. Every kernel here is **integer-only** (i32 add/mul/min); integer
+//! arithmetic is associative and exact, so lane order cannot change the result. Each
+//! SIMD kernel reproduces the scalar reference *bit-for-bit*, including the
+//! **lowest-index-wins** tie-break (`scalar uses strict `d < best_d``, scanning indices
+//! ascending). The `kernel_matches_scalar*` tests are the gate.
+//!
+//! # Never panic
+//!
+//! Each `*_simd` kernel is an `unsafe fn` marked `#[target_feature(enable = …)]`; it is
+//! ONLY ever reached through [`detect`], which gates on `is_*_feature_detected!` (x86) or
+//! a guaranteed-baseline arch (`neon` on aarch64, `simd128` compiled-in on wasm). A host
+//! lacking the feature takes the scalar path, so no illegal instruction can execute. The
+//! `IMAGE_QUANTIZE_SCALAR=1` escape hatch (and the test-only thread-local override) force
+//! the scalar path on a SIMD-capable host to prove the fallback.
+
+use std::sync::OnceLock;
+
+/// Which opaque-scan kernel to run. `Copy` so callers detect once and pass it by value
+/// down the hot loop with no per-pixel cost.
+///
+/// Variants are added per SIMD phase; Phase 0 ships only [`OpaqueKernel::Scalar`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum OpaqueKernel {
+  /// Portable integer reference. Defines the byte-exact result every other kernel
+  /// must reproduce. Always available on every target.
+  Scalar,
+}
+
+/// Selects the opaque-scan kernel for this host, honouring the `IMAGE_QUANTIZE_SCALAR`
+/// escape hatch and (in tests) a thread-local override. Cheap to call repeatedly — the
+/// underlying feature probe is cached by the std macro and the env read by a `OnceLock` —
+/// but callers should still detect ONCE above the per-pixel loop, not per pixel.
+#[inline]
+pub(crate) fn detect() -> OpaqueKernel {
+  #[cfg(test)]
+  {
+    if let Some(forced) = test_override::get() {
+      return forced;
+    }
+  }
+  if force_scalar() {
+    return OpaqueKernel::Scalar;
+  }
+  detect_native()
+}
+
+/// Runtime feature probe, per architecture. Phase 0 has no SIMD variants yet, so every
+/// arch resolves to [`OpaqueKernel::Scalar`]; later phases fill in the `is_*_detected`
+/// branches. Kept separate from [`detect`] so the override / escape-hatch logic is shared.
+#[inline]
+fn detect_native() -> OpaqueKernel {
+  OpaqueKernel::Scalar
+}
+
+/// `true` when `IMAGE_QUANTIZE_SCALAR` is set to a truthy value (`1`/`true`/`yes`). Read
+/// once per process. A production escape hatch: forces the scalar path on any host, so a
+/// suspected SIMD mismatch can be ruled out without a rebuild.
+fn force_scalar() -> bool {
+  static FORCE: OnceLock<bool> = OnceLock::new();
+  *FORCE.get_or_init(|| {
+    std::env::var("IMAGE_QUANTIZE_SCALAR")
+      .map(|v| matches!(v.trim(), "1" | "true" | "yes"))
+      .unwrap_or(false)
+  })
+}
+
+/// Index of the palette entry nearest `q = [L, a, b]` (×100 units) by squared CIE76 ΔE,
+/// over the Structure-of-Arrays palette components. **Opaque fast path only** — the
+/// caller guarantees the palette is fully opaque and the query is opaque, so this exact
+/// `dl²+da²+db²` argmin equals the general `nearest_lab` result.
+///
+/// `l`, `a`, `b` are parallel, equal-length, and non-empty (the caller's palette always
+/// has ≥1 entry). Ties resolve to the **lowest index**.
+#[inline]
+pub(crate) fn opaque_argmin(
+  kernel: OpaqueKernel,
+  l: &[i32],
+  a: &[i32],
+  b: &[i32],
+  q: [i32; 3],
+) -> usize {
+  debug_assert_eq!(l.len(), a.len());
+  debug_assert_eq!(l.len(), b.len());
+  debug_assert!(!l.is_empty());
+  match kernel {
+    OpaqueKernel::Scalar => opaque_scan_scalar(l, a, b, q),
+  }
+}
+
+/// Portable integer reference for [`opaque_argmin`]. Computed in `i64` to mirror
+/// `nearest_lab`'s arithmetic exactly (the values fit `i32`, so every SIMD kernel reaches
+/// the same argmin in `i32`). Scans ascending with strict `<`, so the lowest index wins
+/// on a tie.
+fn opaque_scan_scalar(l: &[i32], a: &[i32], b: &[i32], q: [i32; 3]) -> usize {
+  let [ql, qa, qb] = q;
+  let mut best = 0usize;
+  let mut best_d = i64::MAX;
+  for (i, ((&li, &ai), &bi)) in l.iter().zip(a).zip(b).enumerate() {
+    let dl = (ql - li) as i64;
+    let da = (qa - ai) as i64;
+    let db = (qb - bi) as i64;
+    let d = dl * dl + da * da + db * db;
+    if d < best_d {
+      best_d = d;
+      best = i;
+    }
+  }
+  best
+}
+
+/// Test-only thread-local kernel override, so a single test process can run the same
+/// quantize twice — once on the detected SIMD kernel, once forced to scalar — and assert
+/// byte-identical output. Thread-local (not a global) so parallel tests don't race.
+#[cfg(test)]
+pub(crate) mod test_override {
+  use super::OpaqueKernel;
+  use std::cell::Cell;
+
+  thread_local! {
+    static OVERRIDE: Cell<Option<OpaqueKernel>> = const { Cell::new(None) };
+  }
+
+  pub(crate) fn get() -> Option<OpaqueKernel> {
+    OVERRIDE.with(|c| c.get())
+  }
+
+  pub(crate) fn set(k: Option<OpaqueKernel>) {
+    OVERRIDE.with(|c| c.set(k));
+  }
+
+  /// Runs `f` with [`super::detect`] forced to `k`, restoring the prior override after.
+  pub(crate) fn with<R>(k: OpaqueKernel, f: impl FnOnce() -> R) -> R {
+    let prev = get();
+    set(Some(k));
+    let r = f();
+    set(prev);
+    r
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  /// A tiny deterministic LCG so the equivalence sweeps need no `rand` dep.
+  struct Lcg(u64);
+  impl Lcg {
+    fn next_u32(&mut self) -> u32 {
+      self.0 = self
+        .0
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+      (self.0 >> 32) as u32
+    }
+    /// A pseudo-random Lab component in a generous in-gamut range (×100 units).
+    fn lab(&mut self) -> i32 {
+      (self.next_u32() % 26_001) as i32 - 1000 // roughly [-1000, 25000]
+    }
+  }
+
+  fn build_soa(n: usize, rng: &mut Lcg) -> (Vec<i32>, Vec<i32>, Vec<i32>) {
+    let l = (0..n).map(|_| rng.lab()).collect();
+    let a = (0..n).map(|_| rng.lab()).collect();
+    let b = (0..n).map(|_| rng.lab()).collect();
+    (l, a, b)
+  }
+
+  #[test]
+  fn scalar_argmin_is_lowest_index_on_ties() {
+    // Two identical entries at the exact query: the lower index must win.
+    let l = vec![10, 10, 99];
+    let a = vec![20, 20, 99];
+    let b = vec![30, 30, 99];
+    assert_eq!(opaque_scan_scalar(&l, &a, &b, [10, 20, 30]), 0);
+  }
+
+  #[test]
+  fn scalar_argmin_picks_nearest() {
+    let l = vec![0, 100, 5];
+    let a = vec![0, 100, 5];
+    let b = vec![0, 100, 5];
+    // Query (4,4,4): entry 2 (5,5,5) is closest.
+    assert_eq!(opaque_scan_scalar(&l, &a, &b, [4, 4, 4]), 2);
+  }
+
+  /// Shared equivalence harness reused by every SIMD phase: assert a candidate kernel
+  /// reproduces the scalar reference across many randomized palettes + queries, including
+  /// palette sizes that exercise non-multiple-of-lane-width tails (1..=300) and forced
+  /// exact-tie queries.
+  fn assert_kernel_matches_scalar(
+    name: &str,
+    run: impl Fn(&[i32], &[i32], &[i32], [i32; 3]) -> usize,
+  ) {
+    let mut rng = Lcg(0x9E3779B97F4A7C15);
+    for n in 1..=300usize {
+      let (l, a, b) = build_soa(n, &mut rng);
+      for _ in 0..8 {
+        let q = [rng.lab(), rng.lab(), rng.lab()];
+        let want = opaque_scan_scalar(&l, &a, &b, q);
+        let got = run(&l, &a, &b, q);
+        assert_eq!(got, want, "{name}: n={n} q={q:?}");
+      }
+      // Query that lands exactly on a random entry -> exercises ties / exact zero.
+      let hit = (rng.next_u32() as usize) % n;
+      let q = [l[hit], a[hit], b[hit]];
+      assert_eq!(
+        run(&l, &a, &b, q),
+        opaque_scan_scalar(&l, &a, &b, q),
+        "{name}: exact-hit n={n}"
+      );
+    }
+  }
+
+  #[test]
+  fn scalar_matches_itself() {
+    // Sanity-checks the harness (and the dispatch) before any SIMD kernel exists; later
+    // phases add `kernel_matches_scalar_<isa>` calling the same harness with the intrinsic.
+    assert_kernel_matches_scalar("dispatch-scalar", |l, a, b, q| {
+      opaque_argmin(OpaqueKernel::Scalar, l, a, b, q)
+    });
+  }
+}


### PR DESCRIPTION
## What

SIMD-accelerates the clean-room `pngQuantize` quantizer's hottest inner loop — the
per-pixel **nearest-palette argmin** (`remap_dither`, `remap_nearest`, k-means
assignment + objective). Pure performance: **zero output byte change**.

```
opaque palette + opaque query  ⇒  perceptual metric collapses to
    d = dl² + da² + db²          (squared CIE76 ΔE, pure i32)
```

A new `PaletteLabSoa` cache exposes the palette Lab as Structure-of-Arrays and
takes a SIMD argmin on that opaque fast path; the rarer transparent/general case
stays on the unchanged scalar `nearest_lab`. The kernel is detected **once** and
hoisted above each pixel loop.

## Kernels — 4-lane / 128-bit on every arch

| arch | kernel | gate |
|------|--------|------|
| any | scalar reference (defines the result) | always |
| aarch64 | NEON (4×i32) | NEON is ARMv8 baseline |
| x86_64 | SSE4.1 (4×i32) | `is_x86_feature_detected!("sse4.1")`, else scalar |
| wasm32 | simd128 (4×i32) | compile-time `target_feature="simd128"`, else scalar |

The 8-wide AVX2 kernel was intentionally dropped so **every arch runs the identical
4-lane reduction** — one structure to audit for the cross-platform byte-identity
contract.

## Determinism is sacred — byte-identical across x86 / arm / wasm + run-to-run

The metric is pure integer (`i32` add/mul/min): exact and associative, so lane order
cannot change the argmin. Every SIMD kernel reproduces the scalar reference
**bit-for-bit**, including the lowest-index-wins tie-break (strict per-lane compare +
lowest-index cross-lane reduce + `n%4` scalar tail). Golden index pins and the
run1==run2 determinism test pass **unchanged**. Each intermediate stays `< i32::MAX`
(in-gamut `de ≤ 669_160_034`; even out-of-gamut `|Δ| ≤ ~26 000 ⇒ sum ≈ 2.03e9 < 2³¹`).

## Never panic

A `#[target_feature]` kernel is reached only via runtime/compile detection; a host
lacking the feature takes scalar — no illegal instruction can execute. An
`IMAGE_QUANTIZE_SCALAR=1` env hatch forces scalar on any host.

## Verification

- aarch64 native: **82 tests** (NEON equivalence sweep + end-to-end + determinism + opaque-fast-path).
- x86_64 under Rosetta: **81 tests** incl. `kernel_matches_scalar_sse41` exercising real SSE4.1.
- wasm simd128: standalone `wasm32-wasip1 +simd128` under wasmtime — 2700 sweep checks == scalar.
- Final whole-branch adversarial review (Codex): **approve, no material findings**.

## Local aarch64 perf (criterion, vs pre-SIMD `main`)

| case | before | after | Δ |
|------|--------|-------|---|
| default | 1.16 s | 434 ms | **−62.7%** |
| max_quality_75 | 827 ms | 384 ms | **−53.6%** |
| colors/256 | 1.17 s | 446 ms | **−62.0%** |
| no_dither/256 | 909 ms | 360 ms | **−60.4%** |
| colors/64 | 518 ms | 327 ms | −37.0% |
| colors/16 | 326 ms | 278 ms | −14.6% |

x86 numbers will appear on the **CodSpeed** PR comment (measures the SSE4.1 path).

> Opened to run CI + CodSpeed. **Not for auto-merge** — merge is the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)