### PR TITLE
feat(transformer): add opacity(factor) to scale the alpha channel (#42)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -559,6 +559,37 @@ jobs:
         env:
           NAPI_RS_FORCE_WASI: 'error'
 
+  test-rust-binding:
+    name: Unit test binding (cargo test)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      # nasm builds the aom/AVIF C deps; cmake/clang ship on the macOS runner image.
+      - name: Setup nasm
+        uses: ilammy/setup-nasm@v1
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - name: Cache cargo
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: rust-unit-test-cargo-cache
+      # Runs the binding's pure-Rust unit tests (transformer/avif/etc.), which the AVA
+      # `yarn test` path cannot reach for 16-bit / float / HDR / grayscale color models.
+      - name: cargo test
+        run: cargo test -p napi_rs_image
+        env:
+          # The binding is a cdylib that resolves `napi_*` symbols from the host Node
+          # process at runtime; the unit-test binary has no host, so defer those symbols
+          # at link time (macOS linker) instead of failing on undefined references.
+          RUSTFLAGS: '-C link-arg=-undefined -C link-arg=dynamic_lookup'
+
   benchmark:
     name: Benchmark pngQuantize (CodSpeed)
     runs-on: ubuntu-latest
@@ -618,6 +649,7 @@ jobs:
       - test-linux-aarch64-gnu-binding
       - test-linux-arm-gnueabihf-binding
       - test-wasi-on-nodejs
+      - test-rust-binding
     steps:
       - uses: actions/checkout@v7
       - name: Setup node

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -245,9 +245,7 @@ test('metadata() reflects grayscale colorType (#158)', async (t) => {
 })
 
 test('metadata() reflects fastResize dims + Rgba8 colorType (#158)', async (t) => {
-  const expected = await roundTripMeta(
-    await new Transformer(PNG).fastResize({ width: 256 }).png(),
-  )
+  const expected = await roundTripMeta(await new Transformer(PNG).fastResize({ width: 256 }).png())
   const meta = await new Transformer(PNG).fastResize({ width: 256 }).metadata()
   t.is(meta.width, 256)
   t.is(meta.width, expected.width)
@@ -257,9 +255,7 @@ test('metadata() reflects fastResize dims + Rgba8 colorType (#158)', async (t) =
 
 test('metadata() reflects chained rotate().resize().crop() in order (#158)', async (t) => {
   const buffer = await fs.readFile(join(ORIENTATION_DIR, 'orientation_6.jpg'))
-  const expected = await roundTripMeta(
-    await new Transformer(buffer).rotate().resize(300).crop(10, 10, 100, 80).png(),
-  )
+  const expected = await roundTripMeta(await new Transformer(buffer).rotate().resize(300).crop(10, 10, 100, 80).png())
   const meta = await new Transformer(buffer).rotate().resize(300).crop(10, 10, 100, 80).metadata(true)
   t.is(meta.width, expected.width)
   t.is(meta.height, expected.height)
@@ -381,6 +377,92 @@ test('reuse: no-transform encode borrows cache, two encodes are byte-identical (
   const first = transformer.pngSync()
   const second = transformer.pngSync()
   t.true(Buffer.from(first).equals(Buffer.from(second)), 'borrow path leaves the cached decode untouched')
+})
+
+// https://github.com/Brooooooklyn/Image/issues/42 — set an image's alpha (opacity).
+// `opacity(factor)` multiplies the existing alpha by `factor` (0..1), like CSS opacity.
+test('opacity(factor) multiplies the alpha channel (#42)', async (t) => {
+  // Fully-opaque 2x2 RGBA (every alpha = 255).
+  const opaque = Uint8Array.from([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255])
+  const raw = await Transformer.fromRgbaPixels(opaque, 2, 2).opacity(0.5).rawPixels()
+  // Alpha halved (round(255 * 0.5) = 128); RGB untouched.
+  t.deepEqual([raw[3], raw[7], raw[11], raw[15]], [128, 128, 128, 128])
+  t.is(raw[0], 255)
+  t.is(raw[1], 0)
+  t.is(raw[2], 0)
+})
+
+test('opacity(0) is fully transparent, opacity(1) leaves alpha unchanged (#42)', async (t) => {
+  const opaque = Uint8Array.from([10, 20, 30, 255])
+  const zero = await Transformer.fromRgbaPixels(opaque, 1, 1).opacity(0).rawPixels()
+  t.is(zero[3], 0)
+  const one = await Transformer.fromRgbaPixels(opaque, 1, 1).opacity(1).rawPixels()
+  t.is(one[3], 255)
+})
+
+test('opacity clamps factor above 1 (#42)', async (t) => {
+  const opaque = Uint8Array.from([10, 20, 30, 200])
+  const raw = await Transformer.fromRgbaPixels(opaque, 1, 1).opacity(2).rawPixels()
+  // Clamped to 1.0, so the source alpha is preserved, never overflowing past 255.
+  t.is(raw[3], 200)
+})
+
+test('opacity scales existing partial alpha (#42)', async (t) => {
+  // Source alpha already 100; opacity(0.5) -> round(100 * 0.5) = 50.
+  const semi = Uint8Array.from([10, 20, 30, 100])
+  const raw = await Transformer.fromRgbaPixels(semi, 1, 1).opacity(0.5).rawPixels()
+  t.is(raw[3], 50)
+})
+
+test('opacity converts an RGB source to RGBA in metadata (#42)', async (t) => {
+  // JPEG decodes to Rgb8 (no alpha); opacity must promote it to Rgba8.
+  const meta = await new Transformer(JPEG).opacity(0.5).metadata()
+  t.is(meta.colorType, JsColorType.Rgba8)
+})
+
+// `adjustContrast` (and other value filters) map every channel including alpha, so
+// opacity scales the SOURCE alpha captured before them — otherwise contrast mangles
+// the alpha and the `new = old * factor` contract breaks. Regression for the Codex
+// review on #42. Both positive and (the harder) negative contrast must hold.
+test('opacity scales the source alpha regardless of a staged contrast filter (#42)', async (t) => {
+  const opaque = Uint8Array.from([100, 120, 140, 255])
+  const hi = await Transformer.fromRgbaPixels(opaque, 1, 1).opacity(0.25).adjustContrast(100).rawPixels()
+  t.is(hi[3], 64, 'round(255 * 0.25) survives positive contrast')
+  t.not(hi[0], 100, 'contrast still affects the RGB channels')
+  // Negative contrast pulls 255 toward 128; opacity must still scale the original 255.
+  const lo = await Transformer.fromRgbaPixels(opaque, 1, 1).opacity(0.5).adjustContrast(-50).rawPixels()
+  t.is(lo[3], 128, 'round(255 * 0.5) survives negative contrast')
+})
+
+// A spatial filter (blur) feathers the alpha channel on purpose, so opacity must
+// scale that FEATHERED alpha — not restore the pre-blur hard mask. Only adjustContrast
+// gets the source-alpha snapshot. Regression for the Codex review on #42.
+test('opacity keeps a spatial filter (blur) alpha feathering (#42)', async (t) => {
+  // 4x1 with a hard alpha edge: [0, 0, 255, 255]. blur softens the boundary.
+  const edge = Uint8Array.from([10, 10, 10, 0, 10, 10, 10, 0, 10, 10, 10, 255, 10, 10, 10, 255])
+  const raw = await Transformer.fromRgbaPixels(edge, 4, 1).blur(1.2).opacity(0.5).rawPixels()
+  const alpha = [raw[3], raw[7], raw[11], raw[15]]
+  t.true(alpha[1] > 0, 'blur feathering reaches the transparent side (not a hard 0)')
+  t.true(alpha[2] < 128, 'blur feathering softens the opaque side (not a hard 128)')
+  t.true(alpha[0] <= alpha[1] && alpha[1] <= alpha[2] && alpha[2] <= alpha[3], 'monotonic gradient')
+})
+
+// The #42 "overlap two images without hiding the bottom" use case: fade the TOP
+// image with opacity, then composite it over the bottom with overlay. The bottom
+// must remain visible through the now semi-transparent top.
+test('opacity on the overlay source blends, keeping the bottom visible (#42)', async (t) => {
+  const blueOpaque = Uint8Array.from([0, 0, 255, 255])
+  const redOpaque = Uint8Array.from([255, 0, 0, 255])
+  // Fade the red top to ~50% and encode it for use as an overlay layer.
+  const fadedTop = await Transformer.fromRgbaPixels(redOpaque, 1, 1).opacity(0.5).png()
+  const raw = await Transformer.fromRgbaPixels(blueOpaque, 1, 1).overlay(fadedTop, 0, 0).rawPixels()
+  // Result is a red/blue blend: the top contributes red AND the bottom blue still
+  // shows through (neither pure red nor pure blue).
+  t.true(raw[0] > 100, 'top red contributes')
+  t.true(raw[2] > 100, 'bottom blue is not hidden')
+  // Compositing over an opaque bottom stays (essentially) opaque; the image crate's
+  // integer "over" blend can round 255 down by 1.
+  t.true(raw[3] >= 254, 'composite over an opaque bottom stays opaque')
 })
 
 // rotate: metadata before == metadata after a rawPixels()/encode (no double-rotate).

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -435,8 +435,9 @@ test('opacity scales the source alpha regardless of a staged contrast filter (#4
 })
 
 // A spatial filter (blur) feathers the alpha channel on purpose, so opacity must
-// scale that FEATHERED alpha — not restore the pre-blur hard mask. Only adjustContrast
-// gets the source-alpha snapshot. Regression for the Codex review on #42.
+// scale that FEATHERED alpha — not restore the pre-blur hard mask. adjustContrast's
+// alpha change is undone right after it runs, so spatial filters always feather the
+// true alpha. Regression for the Codex review on #42.
 test('opacity keeps a spatial filter (blur) alpha feathering (#42)', async (t) => {
   // 4x1 with a hard alpha edge: [0, 0, 255, 255]. blur softens the boundary.
   const edge = Uint8Array.from([10, 10, 10, 0, 10, 10, 10, 0, 10, 10, 10, 255, 10, 10, 10, 255])
@@ -445,6 +446,41 @@ test('opacity keeps a spatial filter (blur) alpha feathering (#42)', async (t) =
   t.true(alpha[1] > 0, 'blur feathering reaches the transparent side (not a hard 0)')
   t.true(alpha[2] < 128, 'blur feathering softens the opaque side (not a hard 128)')
   t.true(alpha[0] <= alpha[1] && alpha[1] <= alpha[2] && alpha[2] <= alpha[3], 'monotonic gradient')
+})
+
+// The hardest case: adjustContrast AND a spatial filter staged together. Contrast
+// mangles alpha, but its change is reverted right after it runs, so the LATER blur
+// still feathers the true alpha and opacity scales that feathered result. The earlier
+// fix (snapshot whenever contrast is present, restore at opacity time) collapsed this
+// back to the hard mask. Regression for the Cursor/Codex review on #42 (commit 917d261).
+test('opacity keeps blur feathering even when adjustContrast is also staged (#42)', async (t) => {
+  const edge = Uint8Array.from([10, 10, 10, 0, 10, 10, 10, 0, 10, 10, 10, 255, 10, 10, 10, 255])
+  const raw = await Transformer.fromRgbaPixels(edge, 4, 1).adjustContrast(100).blur(1.2).opacity(0.5).rawPixels()
+  const alpha = [raw[3], raw[7], raw[11], raw[15]]
+  t.true(alpha[1] > 0, 'blur feathering reaches the transparent side despite contrast')
+  t.true(alpha[2] < 128, 'blur feathering softens the opaque side despite contrast')
+  t.true(alpha[0] <= alpha[1] && alpha[1] <= alpha[2] && alpha[2] <= alpha[3], 'monotonic gradient despite contrast')
+})
+
+// Grayscale (LumaA) path: grayscale() yields a LumaA image, so these exercise the
+// alpha-preserving contrast/huerotate helpers on a non-RGB color model in the CI test
+// path. adjustContrast must not touch the alpha that opacity scales.
+test('opacity on a grayscale (LumaA) source preserves alpha through contrast (#42)', async (t) => {
+  const gray = Uint8Array.from([120, 120, 120, 200])
+  const raw = await Transformer.fromRgbaPixels(gray, 1, 1).grayscale().adjustContrast(80).opacity(0.5).rawPixels()
+  // alpha = round(200 * 0.5) = 100, independent of the staged contrast.
+  t.is(raw[3], 100, 'contrast must not change the alpha opacity scales on the LumaA path')
+})
+
+// Hue rotation of grayscale has no hue to rotate: the luma must survive (the crate
+// emitted garbage by treating luma/alpha as RGB). opacity(1) promotes LumaA -> RGBA so
+// rawPixels gives R=G=B=luma.
+test('huerotate leaves a grayscale (LumaA) luma unchanged (#42)', async (t) => {
+  const gray = Uint8Array.from([120, 120, 120, 255])
+  const raw = await Transformer.fromRgbaPixels(gray, 1, 1).grayscale().huerotate(90).opacity(1).rawPixels()
+  t.true(Math.abs(raw[0] - 120) <= 1, `grayscale R preserved through huerotate; got ${raw[0]}`)
+  t.true(Math.abs(raw[2] - 120) <= 1, `grayscale B preserved through huerotate; got ${raw[2]}`)
+  t.is(raw[3], 255, 'alpha preserved')
 })
 
 // The #42 "overlap two images without hiding the bottom" use case: fade the TOP

--- a/packages/binding/index.d.ts
+++ b/packages/binding/index.d.ts
@@ -70,6 +70,19 @@ export declare class Transformer {
    * just like the css webkit filter hue-rotate(180)
    */
   huerotate(hue: number): this
+  /**
+   * Multiply the image's alpha channel by `factor` (clamped to `0.0..=1.0`),
+   * like CSS `opacity`. `1.0` leaves the image unchanged; `0.0` makes it fully
+   * transparent. Existing transparency is preserved (`new = old * factor`), and
+   * the image is promoted to an alpha-capable type while keeping its bit depth
+   * (RGBA8 / RGBA16 / RGBA32F).
+   *
+   * Like every other filter, this applies to *this* image's content; a later
+   * `overlay` is composited on top afterward. To fade an image you are dropping
+   * onto another, call `opacity` on that (top) image first, then pass it to the
+   * bottom image's `overlay`. Handy for fade-out animation frames.
+   */
+  opacity(factor: number): this
   /** Crop a cut-out of this image delimited by the bounding rectangle. */
   crop(x: number, y: number, width: number, height: number): this
   /** Overlay an image at a given coordinate (x, y) */

--- a/packages/binding/index.d.ts
+++ b/packages/binding/index.d.ts
@@ -75,7 +75,8 @@ export declare class Transformer {
    * like CSS `opacity`. `1.0` leaves the image unchanged; `0.0` makes it fully
    * transparent. Existing transparency is preserved (`new = old * factor`), and
    * the image is promoted to an alpha-capable type while keeping its bit depth
-   * (RGBA8 / RGBA16 / RGBA32F).
+   * (RGBA8 / RGBA16 / RGBA32F). Out-of-range float (HDR) alpha is normalized into
+   * `0.0..=1.0` before the factor is applied, so a requested fade is always effective.
    *
    * Like every other filter, this applies to *this* image's content; a later
    * `overlay` is composited on top afterward. To fade an image you are dropping

--- a/packages/binding/src/avif.rs
+++ b/packages/binding/src/avif.rs
@@ -1,4 +1,4 @@
-use image::{DynamicImage, GenericImageView, ImageBuffer, Rgb, buffer::ConvertBuffer};
+use image::{DynamicImage, GenericImageView, ImageBuffer, Rgb, Rgba, buffer::ConvertBuffer};
 use libavif::{AvifData, AvifImage, RgbPixels, YuvFormat};
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -178,7 +178,10 @@ pub(crate) fn encode_avif_inner(
       )
     }
     DynamicImage::ImageRgba16(img) => {
-      let image: ImageBuffer<Rgb<u8>, _> = img.convert();
+      // Keep the alpha channel (convert to RGBA8, not RGB8). The libavif RGB path is
+      // 8-bit, so precision drops to 8-bit regardless, but dropping alpha here made
+      // `.opacity().avif()` on a 16-bit source encode fully opaque (issue #42).
+      let image: ImageBuffer<Rgba<u8>, _> = img.convert();
       let avif_image = image.as_flat_samples();
       encode_image(
         avif_image.as_slice(),
@@ -198,7 +201,8 @@ pub(crate) fn encode_avif_inner(
       )
     }
     DynamicImage::ImageRgba32F(img) => {
-      let image: ImageBuffer<Rgb<u8>, _> = img.convert();
+      // Keep the alpha channel (RGBA8, not RGB8) — same reasoning as `ImageRgba16`.
+      let image: ImageBuffer<Rgba<u8>, _> = img.convert();
       let avif_image = image.as_flat_samples();
       encode_image(
         avif_image.as_slice(),
@@ -234,4 +238,36 @@ fn encode_image(
     rgb.to_image(format)
   };
   Ok(image)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::encode_avif_inner;
+  use image::{DynamicImage, ImageBuffer};
+
+  /// A 16-bit RGBA source with half alpha must keep its transparency through AVIF
+  /// (the libavif RGB path is 8-bit, so precision drops to 8-bit — but the alpha
+  /// channel must NOT be dropped). Guards the Codex P2: `.opacity(0.5).avif()` on a
+  /// 16-bit source was encoding fully opaque because the `ImageRgba16` branch
+  /// converted to `Rgb<u8>`. See issue #42.
+  #[test]
+  fn avif_preserves_alpha_from_rgba16_source() {
+    // 16x16, uniform: opaque-ish color, alpha 0x8000 (~50%). Uniform so the lossy
+    // alpha plane round-trips cleanly.
+    let buf: Vec<u16> = (0..16 * 16)
+      .flat_map(|_| [40000u16, 20000, 10000, 0x8000])
+      .collect();
+    let img = DynamicImage::ImageRgba16(ImageBuffer::from_raw(16, 16, buf).unwrap());
+
+    let data = encode_avif_inner(None, &img).expect("encode avif");
+    let decoded = libavif::decode_rgb(&data).expect("decode avif");
+    let pixels = decoded.to_vec();
+    let channels = pixels.len() / (decoded.width() * decoded.height()) as usize;
+    assert_eq!(channels, 4, "alpha channel must survive AVIF encode");
+    let alpha = pixels[3];
+    assert!(
+      alpha < 200,
+      "alpha must stay ~128 (was halved), not snap back to opaque; got {alpha}"
+    );
+  }
 }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -512,13 +512,16 @@ struct ImageTransformArgs {
   orientation: Option<Orientation>,
   crop: Option<(u32, u32, u32, u32)>,
   overlay: Vec<(Arc<Uint8Array>, i64, i64)>,
+  /// Multiply the alpha channel by this factor (0.0..=1.0). Promotes the image to RGBA8.
+  opacity: Option<f32>,
 }
 
 impl ImageTransformArgs {
   /// Whether any staged transform changes the encoded image's dimensions or
   /// color type. Pure value-filters (invert/contrast/blur/unsharpen/filter3x3/
   /// brighten/huerotate) and the in-place overlay do not, so `metadata()` can
-  /// skip cloning + applying them.
+  /// skip cloning + applying them. `opacity` is included: it promotes the image
+  /// to RGBA8, so `metadata().colorType` must reflect it (like `grayscale`).
   fn changes_dimensions_or_color(&self) -> bool {
     self.rotate
       || self.orientation.is_some()
@@ -526,6 +529,7 @@ impl ImageTransformArgs {
       || self.fast_resize.is_some()
       || self.grayscale
       || self.crop.is_some()
+      || self.opacity.is_some()
   }
 
   /// No staged transform — the encode pipeline only reads the image, so it can borrow the
@@ -545,6 +549,7 @@ impl ImageTransformArgs {
       && self.huerotate.is_none()
       && self.crop.is_none()
       && self.overlay.is_empty()
+      && self.opacity.is_none()
   }
 }
 
@@ -633,6 +638,16 @@ fn apply_transforms(
   if args.grayscale {
     *image = image.grayscale();
   }
+  // Snapshot the source alpha when opacity runs alongside `adjust_contrast`, so opacity
+  // scales the ORIGINAL alpha — `new = old * factor` — instead of a mangled value (issue
+  // #42). `adjust_contrast` is the only staged filter that maps the alpha channel as an
+  // unwanted side effect: `invert`/`brighten`/`huerotate` leave alpha untouched, and the
+  // spatial filters (`blur`/`unsharpen`/`filter3x3`) feather it on purpose — opacity must
+  // keep that feathering, so they are deliberately NOT snapshot. Skipped too for sources
+  // with no alpha (opacity just adds a fully-opaque channel that nothing has touched).
+  let opacity_source_alpha =
+    (for_encode && args.opacity.is_some() && args.contrast.is_some() && image.color().has_alpha())
+      .then(|| capture_alpha(image));
   if for_encode {
     if args.invert {
       image.invert();
@@ -655,6 +670,14 @@ fn apply_transforms(
     if let Some(hue) = args.huerotate {
       *image = image.huerotate(hue);
     }
+  }
+  // Multiply the alpha channel (issue #42), applied AFTER the value filters using the
+  // pre-filter source alpha (see the snapshot above) so color filters never corrupt
+  // the result. Still unconditional (not gated on `for_encode`) so a pending opacity
+  // is reflected in `metadata().colorType`; in that path no filters ran, so the
+  // current alpha IS the source alpha and the snapshot is unnecessary (`None`).
+  if let Some(factor) = args.opacity {
+    apply_opacity(image, factor, opacity_source_alpha.as_deref());
   }
   if let Some((x, y, width, height)) = args.crop {
     *image = image.crop_imm(x, y, width, height);
@@ -1137,6 +1160,22 @@ impl Transformer {
   }
 
   #[napi]
+  /// Multiply the image's alpha channel by `factor` (clamped to `0.0..=1.0`),
+  /// like CSS `opacity`. `1.0` leaves the image unchanged; `0.0` makes it fully
+  /// transparent. Existing transparency is preserved (`new = old * factor`), and
+  /// the image is promoted to an alpha-capable type while keeping its bit depth
+  /// (RGBA8 / RGBA16 / RGBA32F).
+  ///
+  /// Like every other filter, this applies to *this* image's content; a later
+  /// `overlay` is composited on top afterward. To fade an image you are dropping
+  /// onto another, call `opacity` on that (top) image first, then pass it to the
+  /// bottom image's `overlay`. Handy for fade-out animation frames.
+  pub fn opacity(&mut self, factor: f64) -> &Self {
+    self.image_transform_args.opacity = Some(factor as f32);
+    self
+  }
+
+  #[napi]
   /// Crop a cut-out of this image delimited by the bounding rectangle.
   pub fn crop(&mut self, x: u32, y: u32, width: u32, height: u32) -> &Self {
     self.image_transform_args.crop = Some((x, y, width, height));
@@ -1490,6 +1529,60 @@ impl Transformer {
     output.into_buffer_slice(env)
   }
 }
+/// The source alpha channel, normalized to `0.0..=1.0`, in row-major pixel order.
+/// Captured before the value filters so opacity can scale the ORIGINAL alpha (see
+/// `apply_opacity`). `to_rgba32f` normalizes any bit depth (255/65535 -> 1.0).
+fn capture_alpha(image: &DynamicImage) -> Vec<f32> {
+  image.to_rgba32f().pixels().map(|p| p[3]).collect()
+}
+
+/// Multiply the alpha channel by `factor`, preserving the source bit depth.
+///
+/// `factor` is clamped to `0.0..=1.0`; a non-finite `factor` (NaN / ∞) is treated
+/// as `1.0` (identity) so bad input never silently zeroes the image. The image is
+/// promoted to the alpha-capable type *of its own depth* (RGBA8 / RGBA16 / RGBA32F)
+/// instead of always dropping to 8-bit, so 16-bit (e.g. 10-bit HEIC) and HDR float
+/// sources keep their precision. See issue #42 and the bit-depth regression tests.
+///
+/// When `source_alpha` is `Some` (normalized `0.0..=1.0`, one entry per pixel in
+/// row-major order) the new alpha is `source_alpha * factor`, ignoring the image's
+/// current alpha. This is how opacity stays immune to value filters like
+/// `adjust_contrast`, which map the alpha channel and would otherwise corrupt the
+/// `new = old * factor` contract. When `None`, the image's current alpha is scaled.
+fn apply_opacity(image: &mut DynamicImage, factor: f32, source_alpha: Option<&[f32]>) {
+  let factor = if factor.is_finite() {
+    factor.clamp(0.0, 1.0)
+  } else {
+    1.0
+  };
+  match image.color() {
+    ColorType::L16 | ColorType::La16 | ColorType::Rgb16 | ColorType::Rgba16 => {
+      let mut buf = image.to_rgba16();
+      for (i, pixel) in buf.pixels_mut().enumerate() {
+        let base = source_alpha.map_or(pixel[3] as f32, |a| a[i] * 65535.0);
+        pixel[3] = (base * factor).round().clamp(0.0, 65535.0) as u16;
+      }
+      *image = DynamicImage::ImageRgba16(buf);
+    }
+    ColorType::Rgb32F | ColorType::Rgba32F => {
+      let mut buf = image.to_rgba32f();
+      for (i, pixel) in buf.pixels_mut().enumerate() {
+        let base = source_alpha.map_or(pixel[3], |a| a[i]);
+        pixel[3] = (base * factor).clamp(0.0, 1.0);
+      }
+      *image = DynamicImage::ImageRgba32F(buf);
+    }
+    _ => {
+      let mut buf = image.to_rgba8();
+      for (i, pixel) in buf.pixels_mut().enumerate() {
+        let base = source_alpha.map_or(pixel[3] as f32, |a| a[i] * 255.0);
+        pixel[3] = (base * factor).round().clamp(0.0, 255.0) as u8;
+      }
+      *image = DynamicImage::ImageRgba8(buf);
+    }
+  }
+}
+
 #[inline]
 fn parse_exif(
   buf: &[u8],
@@ -1565,5 +1658,106 @@ mod tests {
   #[test]
   fn heic_image_format_is_none() {
     assert_eq!(DetectedFormat::Heic.image_format(), None);
+  }
+
+  use super::apply_opacity;
+  use image::{ColorType, DynamicImage, ImageBuffer, RgbaImage};
+
+  #[test]
+  fn opacity_rgba8_multiplies_alpha_and_keeps_8bit() {
+    let mut img =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 200]).unwrap());
+    apply_opacity(&mut img, 0.5, None);
+    assert_eq!(img.color(), ColorType::Rgba8);
+    let px = img.to_rgba8();
+    // round(200 * 0.5) = 100; color channels untouched.
+    assert_eq!(px.get_pixel(0, 0).0, [10, 20, 30, 100]);
+  }
+
+  #[test]
+  fn opacity_preserves_16bit_depth() {
+    // The bug this guards (Codex review): a 16-bit source must NOT be silently
+    // down-converted to 8-bit. Even the identity factor must keep Rgba16.
+    let mut img = DynamicImage::ImageRgba16(
+      ImageBuffer::from_raw(1, 1, vec![1000u16, 2000, 3000, 40000]).unwrap(),
+    );
+    apply_opacity(&mut img, 1.0, None);
+    assert_eq!(
+      img.color(),
+      ColorType::Rgba16,
+      "identity opacity must not drop to 8-bit"
+    );
+
+    let mut img = DynamicImage::ImageRgba16(
+      ImageBuffer::from_raw(1, 1, vec![1000u16, 2000, 3000, 40000]).unwrap(),
+    );
+    apply_opacity(&mut img, 0.5, None);
+    assert_eq!(img.color(), ColorType::Rgba16);
+    if let DynamicImage::ImageRgba16(buf) = &img {
+      assert_eq!(buf.get_pixel(0, 0).0, [1000, 2000, 3000, 20000]);
+    } else {
+      panic!("expected Rgba16");
+    }
+  }
+
+  #[test]
+  fn opacity_promotes_rgb16_to_rgba16_not_rgba8() {
+    // RGB16 (no alpha) gains an alpha channel but stays 16-bit.
+    let mut img =
+      DynamicImage::ImageRgb16(ImageBuffer::from_raw(1, 1, vec![1000u16, 2000, 3000]).unwrap());
+    apply_opacity(&mut img, 0.5, None);
+    assert_eq!(img.color(), ColorType::Rgba16);
+    if let DynamicImage::ImageRgba16(buf) = &img {
+      // full alpha (65535) scaled by 0.5 -> 32768 (32767.5 rounds up).
+      assert_eq!(buf.get_pixel(0, 0).0[3], 32768);
+    } else {
+      panic!("expected Rgba16");
+    }
+  }
+
+  #[test]
+  fn opacity_preserves_32f_depth() {
+    let mut img =
+      DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.1f32, 0.2, 0.3, 0.8]).unwrap());
+    apply_opacity(&mut img, 0.5, None);
+    assert_eq!(img.color(), ColorType::Rgba32F);
+    if let DynamicImage::ImageRgba32F(buf) = &img {
+      assert!((buf.get_pixel(0, 0).0[3] - 0.4).abs() < 1e-6);
+    } else {
+      panic!("expected Rgba32F");
+    }
+  }
+
+  #[test]
+  fn opacity_clamps_above_one_and_ignores_non_finite() {
+    let mut img =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 200]).unwrap());
+    apply_opacity(&mut img, 2.0, None);
+    assert_eq!(
+      img.to_rgba8().get_pixel(0, 0).0[3],
+      200,
+      "factor > 1 clamps to identity"
+    );
+
+    let mut img =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 200]).unwrap());
+    apply_opacity(&mut img, f32::NAN, None);
+    assert_eq!(
+      img.to_rgba8().get_pixel(0, 0).0[3],
+      200,
+      "NaN must be a no-op, never silently zero the alpha"
+    );
+  }
+
+  #[test]
+  fn opacity_scales_provided_source_alpha_not_current() {
+    // Simulates the post-value-filter state: the live alpha (50) has been mangled by
+    // a filter, but opacity must scale the captured SOURCE alpha (1.0 == fully opaque)
+    // so the result is `1.0 * 0.5 == 128`, not `50 * 0.5`. Guards the Codex review on
+    // opacity vs adjust_contrast (#42).
+    let mut img =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 50]).unwrap());
+    apply_opacity(&mut img, 0.5, Some(&[1.0]));
+    assert_eq!(img.to_rgba8().get_pixel(0, 0).0[3], 128);
   }
 }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -1161,7 +1161,8 @@ impl Transformer {
   /// like CSS `opacity`. `1.0` leaves the image unchanged; `0.0` makes it fully
   /// transparent. Existing transparency is preserved (`new = old * factor`), and
   /// the image is promoted to an alpha-capable type while keeping its bit depth
-  /// (RGBA8 / RGBA16 / RGBA32F).
+  /// (RGBA8 / RGBA16 / RGBA32F). Out-of-range float (HDR) alpha is normalized into
+  /// `0.0..=1.0` before the factor is applied, so a requested fade is always effective.
   ///
   /// Like every other filter, this applies to *this* image's content; a later
   /// `overlay` is composited on top afterward. To fade an image you are dropping
@@ -1705,7 +1706,18 @@ fn apply_opacity(image: &mut DynamicImage, factor: f32) {
     ColorType::Rgb32F | ColorType::Rgba32F => {
       let mut buf = image.to_rgba32f();
       for pixel in buf.pixels_mut() {
-        pixel[3] = (pixel[3] * factor).clamp(0.0, 1.0);
+        // Normalize the SOURCE alpha into the unit range BEFORE applying the factor, so a
+        // requested fade is always effective. Clamping the *product* instead would let an
+        // out-of-range alpha swallow the fade (`4.0 * 0.5 = 2.0` -> clamp -> `1.0`, still
+        // fully opaque). Alpha is normalized `[0,1]` at every depth — the 8/16-bit paths
+        // can't exceed their max and the image crate's f32 `DEFAULT_MAX_VALUE` is 1.0. For
+        // external Rgba32F data `clamp` floors `-∞`/negatives to 0.0 and saturates `+∞`/
+        // values > 1 to 1.0; NaN is undefined under `clamp`, so sanitize it to 0.0. Both
+        // the normalized alpha and the factor are in `[0,1]`, so the product needs no
+        // further clamp.
+        let a = pixel[3];
+        let normalized = if a.is_nan() { 0.0 } else { a.clamp(0.0, 1.0) };
+        pixel[3] = normalized * factor;
       }
       *image = DynamicImage::ImageRgba32F(buf);
     }
@@ -1882,9 +1894,9 @@ mod tests {
   #[test]
   fn opacity_noop_contrast_invisible_for_hdr_float_alpha() {
     // For an Rgba32F image with alpha > 1.0, a no-op adjustContrast(0) must not change
-    // opacity output. `restore_alpha` must put back the raw captured alpha (no early
-    // [0,1] clamp) and let `apply_opacity` do the final clamp — otherwise restore clamps
-    // 4.0 -> 1.0 and opacity returns 0.5 instead of 1.0. Codex adversarial review on #42.
+    // opacity output. `apply_contrast` never touches alpha, so the alpha that reaches
+    // `apply_opacity` is identical whether or not a no-op contrast is staged; opacity then
+    // normalizes it the same way in both paths. Codex adversarial review on #42.
     let base = DynamicImage::ImageRgba32F(
       ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap(),
     );
@@ -2079,6 +2091,75 @@ mod tests {
       assert!((buf.get_pixel(0, 0).0[3] - 0.4).abs() < 1e-6);
     } else {
       panic!("expected Rgba32F");
+    }
+  }
+
+  #[test]
+  fn opacity_normalizes_out_of_range_float_alpha() {
+    // Alpha is opacity, normalized `0.0..=1.0` at EVERY depth (the 8/16-bit paths can't
+    // exceed their max; the image crate's f32 `DEFAULT_MAX_VALUE` is 1.0). The SOURCE alpha
+    // is normalized into the unit range BEFORE the user's factor is applied, so a requested
+    // fade is always effective — clamping the *product* instead would let an out-of-range
+    // alpha swallow the fade and stay fully opaque. A valid in-range alpha follows
+    // `new = old * factor` exactly. Resolves the Cursor/Codex review on #42 in favor of
+    // normalize-source-then-multiply.
+
+    // Out-of-range source normalizes to full opacity under identity opacity.
+    let mut img =
+      DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap());
+    apply_opacity(&mut img, 1.0);
+    let identity = img.to_rgba32f().get_pixel(0, 0).0[3];
+    assert_eq!(identity, 1.0, "4.0 normalizes to full opacity; got {identity}");
+
+    // ...and a real fade still bites: normalize 4.0 -> 1.0, then * 0.5 -> 0.5 (NOT 1.0).
+    let mut img =
+      DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap());
+    apply_opacity(&mut img, 0.5);
+    let faded = img.to_rgba32f().get_pixel(0, 0).0[3];
+    assert_eq!(faded, 0.5, "opacity(0.5) must still fade out-of-range alpha; got {faded}");
+
+    // In-range source: new = old * factor, unchanged by the normalization.
+    let mut img = DynamicImage::ImageRgba32F(
+      ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 0.8]).unwrap(),
+    );
+    apply_opacity(&mut img, 0.5);
+    let in_range = img.to_rgba32f().get_pixel(0, 0).0[3];
+    assert!(
+      (in_range - 0.4).abs() < 1e-6,
+      "in-range alpha follows new = old * factor; got {in_range}"
+    );
+  }
+
+  #[test]
+  fn opacity_saturates_positive_infinite_float_alpha() {
+    // `+∞` is the extreme of "alpha greater than the unit range", so the source normalizes
+    // to 1.0 (full opacity) exactly like a finite alpha > 1.0 does — NOT 0.0 (transparent).
+    // Grouping `+∞` with NaN/negative made opacity flip an "infinitely opaque" pixel to
+    // fully transparent, contradicting the normalized-alpha model. Under identity opacity it
+    // must stay fully opaque. Codex adversarial review on #42.
+    let mut img = DynamicImage::ImageRgba32F(
+      ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, f32::INFINITY]).unwrap(),
+    );
+    apply_opacity(&mut img, 1.0);
+    let a = img.to_rgba32f().get_pixel(0, 0).0[3];
+    assert_eq!(a, 1.0, "+inf alpha must normalize to full opacity; got {a}");
+  }
+
+  #[test]
+  fn opacity_sanitizes_malformed_float_alpha() {
+    // Decoded Rgba32F is external data: a negative, negative-infinite, or NaN source alpha
+    // normalizes to the transparent bound 0.0 (`clamp` floors `-∞`/negatives; NaN is
+    // sanitized), so after multiplying by the factor it stays 0.0 rather than leaking into
+    // raw/composite output. Positive out-of-range alpha normalizes to full opacity instead
+    // (see `opacity_saturates_positive_infinite_float_alpha` and
+    // `opacity_normalizes_out_of_range_float_alpha`). Cursor + Codex review on #42.
+    for bad in [-0.5f32, f32::NEG_INFINITY, f32::NAN] {
+      let mut img = DynamicImage::ImageRgba32F(
+        ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, bad]).unwrap(),
+      );
+      apply_opacity(&mut img, 0.5);
+      let a = img.to_rgba32f().get_pixel(0, 0).0[3];
+      assert_eq!(a, 0.0, "malformed alpha {bad} must sanitize to 0; got {a}");
     }
   }
 

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 
 use image::imageops::overlay;
 use image::{
-  ColorType, DynamicImage, ImageBuffer, ImageEncoder, ImageFormat, RgbaImage, imageops::FilterType,
+  ColorType, DynamicImage, ImageBuffer, ImageEncoder, ImageFormat, Pixel, RgbaImage,
+  imageops::FilterType,
 };
 use libavif::AvifData;
 use napi::bindgen_prelude::*;
@@ -638,22 +639,19 @@ fn apply_transforms(
   if args.grayscale {
     *image = image.grayscale();
   }
-  // Snapshot the source alpha when opacity runs alongside `adjust_contrast`, so opacity
-  // scales the ORIGINAL alpha — `new = old * factor` — instead of a mangled value (issue
-  // #42). `adjust_contrast` is the only staged filter that maps the alpha channel as an
-  // unwanted side effect: `invert`/`brighten`/`huerotate` leave alpha untouched, and the
-  // spatial filters (`blur`/`unsharpen`/`filter3x3`) feather it on purpose — opacity must
-  // keep that feathering, so they are deliberately NOT snapshot. Skipped too for sources
-  // with no alpha (opacity just adds a fully-opaque channel that nothing has touched).
-  let opacity_source_alpha =
-    (for_encode && args.opacity.is_some() && args.contrast.is_some() && image.color().has_alpha())
-      .then(|| capture_alpha(image));
   if for_encode {
+    // Alpha invariant (#42): the value/color filters must leave alpha untouched so opacity
+    // scales the real transparency, while the SPATIAL filters (`blur`/`unsharpen`/
+    // `filter3x3`) feather alpha on purpose. `invert` (passes `rgba[3]` through) and
+    // `brighten` (`map_with_alpha(|a| a)`) already do; `apply_contrast` and
+    // `apply_huerotate` are depth-aware, alpha-preserving re-implementations of the crate
+    // filters (which otherwise scale/crush alpha as a side effect). Nothing here needs an
+    // alpha snapshot.
     if args.invert {
       image.invert();
     }
     if let Some(contrast) = args.contrast {
-      *image = image.adjust_contrast(contrast);
+      apply_contrast(image, contrast);
     }
     if let Some(blur) = args.blur {
       *image = image.blur(blur);
@@ -668,16 +666,15 @@ fn apply_transforms(
       *image = image.brighten(brighten);
     }
     if let Some(hue) = args.huerotate {
-      *image = image.huerotate(hue);
+      apply_huerotate(image, hue);
     }
   }
-  // Multiply the alpha channel (issue #42), applied AFTER the value filters using the
-  // pre-filter source alpha (see the snapshot above) so color filters never corrupt
-  // the result. Still unconditional (not gated on `for_encode`) so a pending opacity
-  // is reflected in `metadata().colorType`; in that path no filters ran, so the
-  // current alpha IS the source alpha and the snapshot is unnecessary (`None`).
+  // Multiply the alpha channel (issue #42), applied AFTER the value filters. The value
+  // filters leave alpha untouched and the spatial filters feather it on purpose, so the
+  // CURRENT alpha is exactly what opacity should scale. Unconditional (not gated on
+  // `for_encode`) so a pending opacity is reflected in `metadata().colorType`.
   if let Some(factor) = args.opacity {
-    apply_opacity(image, factor, opacity_source_alpha.as_deref());
+    apply_opacity(image, factor);
   }
   if let Some((x, y, width, height)) = args.crop {
     *image = image.crop_imm(x, y, width, height);
@@ -1529,11 +1526,154 @@ impl Transformer {
     output.into_buffer_slice(env)
   }
 }
-/// The source alpha channel, normalized to `0.0..=1.0`, in row-major pixel order.
-/// Captured before the value filters so opacity can scale the ORIGINAL alpha (see
-/// `apply_opacity`). `to_rgba32f` normalizes any bit depth (255/65535 -> 1.0).
-fn capture_alpha(image: &DynamicImage) -> Vec<f32> {
-  image.to_rgba32f().pixels().map(|p| p[3]).collect()
+/// Adjust the contrast of `image`'s color/luma channels by `contrast`, preserving bit
+/// depth and the alpha channel.
+///
+/// `image`'s `adjust_contrast` maps EVERY channel with `pixel.map`, including alpha — so
+/// it scales transparency as an unwanted side effect (contrast is a luma/color op). This
+/// applies the identical per-channel curve `clamp(((c/max - 0.5) * percent + 0.5) * max)`
+/// using the real per-depth `max` (so color output is byte-identical to the crate) but
+/// via `map_with_alpha`, leaving the alpha channel untouched. Operates in place per native
+/// type — no full-image copy. See issue #42.
+fn apply_contrast(image: &mut DynamicImage, contrast: f32) {
+  let percent = ((100.0 + contrast) / 100.0).powi(2);
+  // The crate truncates (`NumCast`/`as`) after clamping, so we cast (not round) to match.
+  let curve = move |c: f32, max: f32| (((c / max - 0.5) * percent + 0.5) * max).clamp(0.0, max);
+  macro_rules! contrast_int {
+    ($buf:expr, $ty:ty, $max:expr) => {{
+      for pixel in $buf.pixels_mut() {
+        *pixel = pixel.map_with_alpha(|c| curve(c as f32, $max) as $ty, |a| a);
+      }
+    }};
+  }
+  match image {
+    DynamicImage::ImageLuma8(buf) => contrast_int!(buf, u8, 255.0),
+    DynamicImage::ImageLumaA8(buf) => contrast_int!(buf, u8, 255.0),
+    DynamicImage::ImageRgb8(buf) => contrast_int!(buf, u8, 255.0),
+    DynamicImage::ImageRgba8(buf) => contrast_int!(buf, u8, 255.0),
+    DynamicImage::ImageLuma16(buf) => contrast_int!(buf, u16, 65535.0),
+    DynamicImage::ImageLumaA16(buf) => contrast_int!(buf, u16, 65535.0),
+    DynamicImage::ImageRgb16(buf) => contrast_int!(buf, u16, 65535.0),
+    DynamicImage::ImageRgba16(buf) => contrast_int!(buf, u16, 65535.0),
+    DynamicImage::ImageRgb32F(buf) => {
+      for pixel in buf.pixels_mut() {
+        *pixel = pixel.map_with_alpha(|c| curve(c, 1.0), |a| a);
+      }
+    }
+    DynamicImage::ImageRgba32F(buf) => {
+      for pixel in buf.pixels_mut() {
+        *pixel = pixel.map_with_alpha(|c| curve(c, 1.0), |a| a);
+      }
+    }
+    _ => {}
+  }
+}
+
+/// Hue-rotate `image` by `degrees`, preserving bit depth and alpha.
+///
+/// `image` 0.25's `DynamicImage::huerotate` clamps EVERY output channel against a
+/// hardcoded `255`, which crushes >8-bit color to 8-bit and clamps alpha to 255 (it
+/// also treats grayscale luma/alpha as RGB, emitting garbage). This re-implements the
+/// same standard hue-rotation matrix (so 8-bit RGB/RGBA output stays byte-identical to
+/// the crate) but clamps each color channel to its real per-depth max — 255 (`u8`),
+/// 65535 (`u16`), 1.0 (`f32`) — and copies the alpha channel through untouched.
+/// Grayscale has no hue, so rotating it leaves luma (and alpha) unchanged.
+fn apply_huerotate(image: &mut DynamicImage, degrees: i32) {
+  // 0 and 360 degrees are documented no-ops. Short-circuit so the identity rotation is
+  // EXACTLY the input for every type (no float rounding, and NaN / HDR samples pass
+  // through untouched instead of being run through the matrix).
+  if degrees.rem_euclid(360) == 0 {
+    return;
+  }
+  let angle = (degrees as f64).to_radians();
+  let (cosv, sinv) = (angle.cos(), angle.sin());
+  // Same coefficients as `image`'s `imageops::huerotate` / CSS `hue-rotate()`; each row
+  // sums to 1.0, so a neutral gray maps to itself.
+  let m = [
+    0.213 + cosv * 0.787 - sinv * 0.213,
+    0.715 - cosv * 0.715 - sinv * 0.715,
+    0.072 - cosv * 0.072 + sinv * 0.928,
+    0.213 - cosv * 0.213 + sinv * 0.143,
+    0.715 + cosv * 0.285 + sinv * 0.140,
+    0.072 - cosv * 0.072 - sinv * 0.283,
+    0.213 - cosv * 0.213 - sinv * 0.787,
+    0.715 - cosv * 0.715 + sinv * 0.715,
+    0.072 + cosv * 0.928 + sinv * 0.072,
+  ];
+  let rotate = |r: f64, g: f64, b: f64| {
+    (
+      m[0] * r + m[1] * g + m[2] * b,
+      m[3] * r + m[4] * g + m[5] * b,
+      m[6] * r + m[7] * g + m[8] * b,
+    )
+  };
+  // Lower-clamp a float channel to 0 (no negative light) while PRESERVING NaN: `NaN < 0.0`
+  // is false, so NaN passes through instead of collapsing to 0 like `f32::max` would.
+  // HDR magnitudes above 1.0 are kept.
+  let clamp_lo = |v: f64| -> f32 {
+    let v = v as f32;
+    if v < 0.0 { 0.0 } else { v }
+  };
+  match image {
+    // Integer RGB(A): truncate toward zero after clamping to the real max, matching the
+    // crate's `NumCast::from` (`as` cast) so 8-bit output is identical.
+    DynamicImage::ImageRgb8(buf) => {
+      for p in buf.pixels_mut() {
+        let (r, g, b) = rotate(p[0] as f64, p[1] as f64, p[2] as f64);
+        p[0] = r.clamp(0.0, 255.0) as u8;
+        p[1] = g.clamp(0.0, 255.0) as u8;
+        p[2] = b.clamp(0.0, 255.0) as u8;
+      }
+    }
+    DynamicImage::ImageRgba8(buf) => {
+      for p in buf.pixels_mut() {
+        let (r, g, b) = rotate(p[0] as f64, p[1] as f64, p[2] as f64);
+        p[0] = r.clamp(0.0, 255.0) as u8;
+        p[1] = g.clamp(0.0, 255.0) as u8;
+        p[2] = b.clamp(0.0, 255.0) as u8;
+        // p[3] (alpha) left untouched.
+      }
+    }
+    DynamicImage::ImageRgb16(buf) => {
+      for p in buf.pixels_mut() {
+        let (r, g, b) = rotate(p[0] as f64, p[1] as f64, p[2] as f64);
+        p[0] = r.clamp(0.0, 65535.0) as u16;
+        p[1] = g.clamp(0.0, 65535.0) as u16;
+        p[2] = b.clamp(0.0, 65535.0) as u16;
+      }
+    }
+    DynamicImage::ImageRgba16(buf) => {
+      for p in buf.pixels_mut() {
+        let (r, g, b) = rotate(p[0] as f64, p[1] as f64, p[2] as f64);
+        p[0] = r.clamp(0.0, 65535.0) as u16;
+        p[1] = g.clamp(0.0, 65535.0) as u16;
+        p[2] = b.clamp(0.0, 65535.0) as u16;
+        // p[3] (alpha) left untouched.
+      }
+    }
+    // Float channels are HDR: clamp only the lower bound to 0 (no negative light) and
+    // preserve finite magnitudes above 1.0 instead of clipping them to SDR. `max(0.0)`
+    // also sanitizes NaN to 0.
+    DynamicImage::ImageRgb32F(buf) => {
+      for p in buf.pixels_mut() {
+        let (r, g, b) = rotate(p[0] as f64, p[1] as f64, p[2] as f64);
+        p[0] = clamp_lo(r);
+        p[1] = clamp_lo(g);
+        p[2] = clamp_lo(b);
+      }
+    }
+    DynamicImage::ImageRgba32F(buf) => {
+      for p in buf.pixels_mut() {
+        let (r, g, b) = rotate(p[0] as f64, p[1] as f64, p[2] as f64);
+        p[0] = clamp_lo(r);
+        p[1] = clamp_lo(g);
+        p[2] = clamp_lo(b);
+        // p[3] (alpha) left untouched.
+      }
+    }
+    // Grayscale (Luma / LumaA, any depth): no hue to rotate — leave luma and alpha as-is.
+    _ => {}
+  }
 }
 
 /// Multiply the alpha channel by `factor`, preserving the source bit depth.
@@ -1544,12 +1684,11 @@ fn capture_alpha(image: &DynamicImage) -> Vec<f32> {
 /// instead of always dropping to 8-bit, so 16-bit (e.g. 10-bit HEIC) and HDR float
 /// sources keep their precision. See issue #42 and the bit-depth regression tests.
 ///
-/// When `source_alpha` is `Some` (normalized `0.0..=1.0`, one entry per pixel in
-/// row-major order) the new alpha is `source_alpha * factor`, ignoring the image's
-/// current alpha. This is how opacity stays immune to value filters like
-/// `adjust_contrast`, which map the alpha channel and would otherwise corrupt the
-/// `new = old * factor` contract. When `None`, the image's current alpha is scaled.
-fn apply_opacity(image: &mut DynamicImage, factor: f32, source_alpha: Option<&[f32]>) {
+/// Scales the image's CURRENT alpha. The value filters (`apply_contrast`,
+/// `apply_huerotate`, `invert`, `brighten`) leave alpha untouched and the spatial filters
+/// (`blur`/`unsharpen`/`filter3x3`) feather alpha on purpose, so the current alpha is
+/// always exactly what opacity should scale.
+fn apply_opacity(image: &mut DynamicImage, factor: f32) {
   let factor = if factor.is_finite() {
     factor.clamp(0.0, 1.0)
   } else {
@@ -1558,25 +1697,22 @@ fn apply_opacity(image: &mut DynamicImage, factor: f32, source_alpha: Option<&[f
   match image.color() {
     ColorType::L16 | ColorType::La16 | ColorType::Rgb16 | ColorType::Rgba16 => {
       let mut buf = image.to_rgba16();
-      for (i, pixel) in buf.pixels_mut().enumerate() {
-        let base = source_alpha.map_or(pixel[3] as f32, |a| a[i] * 65535.0);
-        pixel[3] = (base * factor).round().clamp(0.0, 65535.0) as u16;
+      for pixel in buf.pixels_mut() {
+        pixel[3] = (pixel[3] as f32 * factor).round().clamp(0.0, 65535.0) as u16;
       }
       *image = DynamicImage::ImageRgba16(buf);
     }
     ColorType::Rgb32F | ColorType::Rgba32F => {
       let mut buf = image.to_rgba32f();
-      for (i, pixel) in buf.pixels_mut().enumerate() {
-        let base = source_alpha.map_or(pixel[3], |a| a[i]);
-        pixel[3] = (base * factor).clamp(0.0, 1.0);
+      for pixel in buf.pixels_mut() {
+        pixel[3] = (pixel[3] * factor).clamp(0.0, 1.0);
       }
       *image = DynamicImage::ImageRgba32F(buf);
     }
     _ => {
       let mut buf = image.to_rgba8();
-      for (i, pixel) in buf.pixels_mut().enumerate() {
-        let base = source_alpha.map_or(pixel[3] as f32, |a| a[i] * 255.0);
-        pixel[3] = (base * factor).round().clamp(0.0, 255.0) as u8;
+      for pixel in buf.pixels_mut() {
+        pixel[3] = (pixel[3] as f32 * factor).round().clamp(0.0, 255.0) as u8;
       }
       *image = DynamicImage::ImageRgba8(buf);
     }
@@ -1660,14 +1796,232 @@ mod tests {
     assert_eq!(DetectedFormat::Heic.image_format(), None);
   }
 
-  use super::apply_opacity;
+  use super::{
+    ImageTransformArgs, apply_contrast, apply_huerotate, apply_opacity, apply_transforms,
+  };
   use image::{ColorType, DynamicImage, ImageBuffer, RgbaImage};
+
+  #[test]
+  fn huerotate_preserves_16bit_color_through_pipeline() {
+    // `image` 0.25's `DynamicImage::huerotate` clamps every channel to a hardcoded 255,
+    // crushing 16-bit color to 8-bit. The pipeline must use a depth-aware hue rotation:
+    // `huerotate(0)` is the identity rotation, so a 16-bit color must return unchanged,
+    // never crushed to 255. Guards the Codex adversarial review on #42.
+    let mut img =
+      DynamicImage::ImageRgb16(ImageBuffer::from_raw(1, 1, vec![40000u16, 20000, 10000]).unwrap());
+    let args = ImageTransformArgs {
+      huerotate: Some(0),
+      ..Default::default()
+    };
+    apply_transforms(&mut img, &args, None, true).unwrap();
+    assert_eq!(img.color(), ColorType::Rgb16, "must stay 16-bit");
+    assert_eq!(
+      img.to_rgb16().get_pixel(0, 0).0,
+      [40000, 20000, 10000],
+      "16-bit color must survive huerotate, not crush to 255"
+    );
+  }
+
+  #[test]
+  fn huerotate_8bit_matches_image_crate() {
+    // The custom hue rotation must be byte-identical to the crate for 8-bit RGB/RGBA
+    // (where the crate's 255 max is already correct), so existing 8-bit output never
+    // changes. Alpha must pass through untouched.
+    let base = DynamicImage::ImageRgba8(
+      RgbaImage::from_raw(2, 1, vec![200, 50, 100, 255, 10, 220, 30, 128]).unwrap(),
+    );
+    // Non-zero angles must match the crate byte-for-byte. (0 / 360 are the identity
+    // fast-path, which is intentionally exact and may differ from the crate's matrix.)
+    for angle in [45, 90, 180, 270, -90] {
+      let mut mine = base.clone();
+      apply_huerotate(&mut mine, angle);
+      let theirs = base.huerotate(angle);
+      assert_eq!(
+        mine.to_rgba8(),
+        theirs.to_rgba8(),
+        "8-bit huerotate must match the image crate at {angle} deg"
+      );
+    }
+  }
+
+  #[test]
+  fn huerotate_identity_preserves_nan_and_hdr_for_float() {
+    // 0 / 360 are documented no-ops: the identity fast-path must return the input bit for
+    // bit, including NaN and HDR (>1.0) float samples. The matrix path would contaminate
+    // finite neighbors of a NaN channel and zero them. Codex adversarial review on #42.
+    let base = DynamicImage::ImageRgba32F(
+      ImageBuffer::from_raw(1, 1, vec![f32::NAN, 0.3, 2.5, 1.0]).unwrap(),
+    );
+    for angle in [0, 360, -360, 720] {
+      let mut img = base.clone();
+      apply_huerotate(&mut img, angle);
+      let p = img.to_rgba32f().get_pixel(0, 0).0;
+      assert!(p[0].is_nan(), "NaN preserved at {angle} deg");
+      assert_eq!(p[1], 0.3, "finite neighbor preserved at {angle} deg");
+      assert_eq!(p[2], 2.5, "HDR neighbor preserved at {angle} deg");
+      assert_eq!(p[3], 1.0, "alpha preserved at {angle} deg");
+    }
+  }
+
+  #[test]
+  fn huerotate_preserves_16bit_alpha_directly() {
+    // The depth-aware hue rotation keeps 16-bit alpha (the crate clamped it to 255) and
+    // keeps 16-bit color out of the 8-bit range.
+    let mut img = DynamicImage::ImageRgba16(
+      ImageBuffer::from_raw(1, 1, vec![40000u16, 20000, 10000, 50000]).unwrap(),
+    );
+    apply_huerotate(&mut img, 90);
+    let px = img.to_rgba16().get_pixel(0, 0).0;
+    assert_eq!(px[3], 50000, "16-bit alpha must pass through, not clamp to 255");
+    assert!(
+      px[0] as u32 + px[1] as u32 + px[2] as u32 > 1000,
+      "16-bit color must not be crushed to ~255; got {px:?}"
+    );
+  }
+
+  #[test]
+  fn opacity_noop_contrast_invisible_for_hdr_float_alpha() {
+    // For an Rgba32F image with alpha > 1.0, a no-op adjustContrast(0) must not change
+    // opacity output. `restore_alpha` must put back the raw captured alpha (no early
+    // [0,1] clamp) and let `apply_opacity` do the final clamp — otherwise restore clamps
+    // 4.0 -> 1.0 and opacity returns 0.5 instead of 1.0. Codex adversarial review on #42.
+    let base = DynamicImage::ImageRgba32F(
+      ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap(),
+    );
+    let alpha_of = |contrast: Option<f32>| {
+      let mut img = base.clone();
+      let args = ImageTransformArgs {
+        contrast,
+        opacity: Some(0.5),
+        ..Default::default()
+      };
+      apply_transforms(&mut img, &args, None, true).unwrap();
+      img.to_rgba32f().get_pixel(0, 0).0[3]
+    };
+    let without = alpha_of(None);
+    let with_noop = alpha_of(Some(0.0));
+    assert!(
+      (without - with_noop).abs() < 1e-6,
+      "no-op contrast(0) changed HDR-alpha opacity output: {without} vs {with_noop}"
+    );
+  }
+
+  #[test]
+  fn huerotate_nonzero_preserves_nan_for_float() {
+    // A NaN sample must survive a real (non-zero) hue rotation rather than silently
+    // collapse to 0 (black). The rotation matrix contaminates the other color channels
+    // with NaN too — mathematically honest — but we must not turn NaN into valid black.
+    // Codex adversarial review on #42.
+    let mut img = DynamicImage::ImageRgba32F(
+      ImageBuffer::from_raw(1, 1, vec![f32::NAN, 0.3, 0.4, 0.9]).unwrap(),
+    );
+    apply_huerotate(&mut img, 90);
+    let p = img.to_rgba32f().get_pixel(0, 0).0;
+    assert!(
+      p[0].is_nan(),
+      "NaN must survive a non-zero hue rotation, not become 0; got {}",
+      p[0]
+    );
+    assert_eq!(p[3], 0.9, "alpha untouched");
+  }
+
+  #[test]
+  fn huerotate_preserves_hdr_float_above_one() {
+    // Float images can hold HDR values above 1.0. `huerotate(0)` is the identity rotation,
+    // so an HDR channel must survive — never clipped to 1.0. The crate clamped float to
+    // 255, so it preserved these; our depth-aware impl must not regress. Guards the Codex
+    // adversarial review on #42.
+    let mut img = DynamicImage::ImageRgba32F(
+      ImageBuffer::from_raw(1, 1, vec![2.5f32, 0.3, 1.8, 4.0]).unwrap(),
+    );
+    apply_huerotate(&mut img, 0);
+    if let DynamicImage::ImageRgba32F(buf) = &img {
+      let p = buf.get_pixel(0, 0).0;
+      assert!(
+        (p[0] - 2.5).abs() < 1e-4,
+        "HDR R must survive identity hue rotation; got {}",
+        p[0]
+      );
+      assert!((p[1] - 0.3).abs() < 1e-4, "G survives; got {}", p[1]);
+      assert!((p[2] - 1.8).abs() < 1e-4, "HDR B must survive; got {}", p[2]);
+      assert!((p[3] - 4.0).abs() < 1e-6, "alpha untouched; got {}", p[3]);
+    } else {
+      panic!("expected Rgba32F");
+    }
+  }
+
+  #[test]
+  fn huerotate_leaves_grayscale_luma_unchanged() {
+    // Grayscale has no hue, so rotating it is a no-op on luma (the crate emitted garbage
+    // by treating luma/alpha as RGB). Alpha is preserved too.
+    let mut img =
+      DynamicImage::ImageLumaA8(ImageBuffer::from_raw(1, 1, vec![120u8, 200]).unwrap());
+    apply_huerotate(&mut img, 90);
+    assert_eq!(img.color(), ColorType::La8, "grayscale stays grayscale");
+    if let DynamicImage::ImageLumaA8(buf) = &img {
+      assert_eq!(buf.get_pixel(0, 0).0, [120, 200], "luma and alpha unchanged");
+    } else {
+      panic!("expected LumaA8");
+    }
+  }
+
+  #[test]
+  fn contrast_alpha_is_independent_of_staged_opacity() {
+    // adjust_contrast must never change the alpha channel (it is a luma/color op), so
+    // staging a documented no-op opacity(1) must not change the result. Alpha
+    // preservation around contrast is UNCONDITIONAL, not coupled to opacity being staged.
+    // Codex adversarial review on #42.
+    let base =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![100, 120, 140, 200]).unwrap());
+    let alpha = |opacity: Option<f32>| {
+      let mut img = base.clone();
+      let args = ImageTransformArgs {
+        contrast: Some(50.0),
+        opacity,
+        ..Default::default()
+      };
+      apply_transforms(&mut img, &args, None, true).unwrap();
+      img.to_rgba8().get_pixel(0, 0).0[3]
+    };
+    assert_eq!(alpha(None), 200, "contrast alone must leave alpha untouched");
+    assert_eq!(alpha(Some(1.0)), 200, "opacity(1) must be a true no-op");
+    assert_eq!(
+      alpha(None),
+      alpha(Some(1.0)),
+      "a staged no-op opacity must not change contrast output"
+    );
+  }
+
+  #[test]
+  fn opacity_preserves_16bit_alpha_through_contrast_and_huerotate() {
+    // `huerotate` in image 0.25 clamps the 4th channel to 255, destroying 16-bit alpha,
+    // and it runs AFTER contrast in the pipeline. Value filters (contrast, huerotate)
+    // must leave the alpha that opacity scales untouched: a 16-bit alpha of 40000 scaled
+    // by 0.5 must land near 20000, never ~128 (255 * 0.5). Guards the Codex adversarial
+    // review on #42 (a regression of the contrast-only restore).
+    let mut img = DynamicImage::ImageRgba16(
+      ImageBuffer::from_raw(1, 1, vec![40000u16, 20000, 10000, 40000]).unwrap(),
+    );
+    let args = ImageTransformArgs {
+      contrast: Some(100.0),
+      huerotate: Some(90),
+      opacity: Some(0.5),
+      ..Default::default()
+    };
+    apply_transforms(&mut img, &args, None, true).unwrap();
+    assert_eq!(img.color(), ColorType::Rgba16, "must stay 16-bit");
+    let alpha = img.to_rgba16().get_pixel(0, 0).0[3];
+    assert!(
+      (19000..=21000).contains(&alpha),
+      "16-bit alpha 40000 * 0.5 ~= 20000 must survive contrast+huerotate; got {alpha}"
+    );
+  }
 
   #[test]
   fn opacity_rgba8_multiplies_alpha_and_keeps_8bit() {
     let mut img =
       DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 200]).unwrap());
-    apply_opacity(&mut img, 0.5, None);
+    apply_opacity(&mut img, 0.5);
     assert_eq!(img.color(), ColorType::Rgba8);
     let px = img.to_rgba8();
     // round(200 * 0.5) = 100; color channels untouched.
@@ -1681,7 +2035,7 @@ mod tests {
     let mut img = DynamicImage::ImageRgba16(
       ImageBuffer::from_raw(1, 1, vec![1000u16, 2000, 3000, 40000]).unwrap(),
     );
-    apply_opacity(&mut img, 1.0, None);
+    apply_opacity(&mut img, 1.0);
     assert_eq!(
       img.color(),
       ColorType::Rgba16,
@@ -1691,7 +2045,7 @@ mod tests {
     let mut img = DynamicImage::ImageRgba16(
       ImageBuffer::from_raw(1, 1, vec![1000u16, 2000, 3000, 40000]).unwrap(),
     );
-    apply_opacity(&mut img, 0.5, None);
+    apply_opacity(&mut img, 0.5);
     assert_eq!(img.color(), ColorType::Rgba16);
     if let DynamicImage::ImageRgba16(buf) = &img {
       assert_eq!(buf.get_pixel(0, 0).0, [1000, 2000, 3000, 20000]);
@@ -1705,7 +2059,7 @@ mod tests {
     // RGB16 (no alpha) gains an alpha channel but stays 16-bit.
     let mut img =
       DynamicImage::ImageRgb16(ImageBuffer::from_raw(1, 1, vec![1000u16, 2000, 3000]).unwrap());
-    apply_opacity(&mut img, 0.5, None);
+    apply_opacity(&mut img, 0.5);
     assert_eq!(img.color(), ColorType::Rgba16);
     if let DynamicImage::ImageRgba16(buf) = &img {
       // full alpha (65535) scaled by 0.5 -> 32768 (32767.5 rounds up).
@@ -1719,7 +2073,7 @@ mod tests {
   fn opacity_preserves_32f_depth() {
     let mut img =
       DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.1f32, 0.2, 0.3, 0.8]).unwrap());
-    apply_opacity(&mut img, 0.5, None);
+    apply_opacity(&mut img, 0.5);
     assert_eq!(img.color(), ColorType::Rgba32F);
     if let DynamicImage::ImageRgba32F(buf) = &img {
       assert!((buf.get_pixel(0, 0).0[3] - 0.4).abs() < 1e-6);
@@ -1732,7 +2086,7 @@ mod tests {
   fn opacity_clamps_above_one_and_ignores_non_finite() {
     let mut img =
       DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 200]).unwrap());
-    apply_opacity(&mut img, 2.0, None);
+    apply_opacity(&mut img, 2.0);
     assert_eq!(
       img.to_rgba8().get_pixel(0, 0).0[3],
       200,
@@ -1741,7 +2095,7 @@ mod tests {
 
     let mut img =
       DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 200]).unwrap());
-    apply_opacity(&mut img, f32::NAN, None);
+    apply_opacity(&mut img, f32::NAN);
     assert_eq!(
       img.to_rgba8().get_pixel(0, 0).0[3],
       200,
@@ -1750,14 +2104,85 @@ mod tests {
   }
 
   #[test]
-  fn opacity_scales_provided_source_alpha_not_current() {
-    // Simulates the post-value-filter state: the live alpha (50) has been mangled by
-    // a filter, but opacity must scale the captured SOURCE alpha (1.0 == fully opaque)
-    // so the result is `1.0 * 0.5 == 128`, not `50 * 0.5`. Guards the Codex review on
-    // opacity vs adjust_contrast (#42).
-    let mut img =
-      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 50]).unwrap());
-    apply_opacity(&mut img, 0.5, Some(&[1.0]));
-    assert_eq!(img.to_rgba8().get_pixel(0, 0).0[3], 128);
+  fn contrast_color_matches_image_crate() {
+    // `apply_contrast` must produce the SAME color as the crate's `adjust_contrast` (it
+    // differs only by preserving alpha). On Rgb8 (no alpha) the two must be byte-identical.
+    let base = DynamicImage::ImageRgb8(
+      image::RgbImage::from_raw(2, 1, vec![200, 50, 100, 10, 220, 30]).unwrap(),
+    );
+    for c in [-50.0f32, -10.0, 0.0, 25.0, 100.0] {
+      let mut mine = base.clone();
+      apply_contrast(&mut mine, c);
+      let theirs = base.adjust_contrast(c);
+      assert_eq!(
+        mine.to_rgb8(),
+        theirs.to_rgb8(),
+        "contrast color must match the image crate at {c}"
+      );
+    }
+  }
+
+  #[test]
+  fn contrast_preserves_alpha_and_matches_crate_color_rgba() {
+    // On RGBA, color must match the crate while alpha is preserved (the crate mangles it).
+    let base =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![200, 50, 100, 200]).unwrap());
+    let mine = {
+      let mut img = base.clone();
+      apply_contrast(&mut img, 60.0);
+      img.to_rgba8().get_pixel(0, 0).0
+    };
+    let crate_px = base.adjust_contrast(60.0).to_rgba8().get_pixel(0, 0).0;
+    assert_eq!(mine[0..3], crate_px[0..3], "color channels must match the crate");
+    assert_eq!(mine[3], 200, "alpha must be preserved");
+    assert_ne!(crate_px[3], 200, "sanity: the crate's adjust_contrast does mangle this alpha");
+  }
+
+  #[test]
+  fn contrast_preserves_16bit_alpha_and_depth() {
+    let mut img = DynamicImage::ImageRgba16(
+      ImageBuffer::from_raw(1, 1, vec![40000u16, 20000, 10000, 50000]).unwrap(),
+    );
+    apply_contrast(&mut img, 50.0);
+    assert_eq!(img.color(), ColorType::Rgba16, "must stay 16-bit");
+    assert_eq!(
+      img.to_rgba16().get_pixel(0, 0).0[3],
+      50000,
+      "16-bit alpha must be preserved, not scaled/crushed"
+    );
+  }
+
+  #[test]
+  fn contrast_noop_is_invisible_for_lumaa_pipeline() {
+    // A no-op `adjustContrast(0)` must not change downstream output. `apply_contrast` keeps
+    // the LumaA color model (does not promote to RGBA), so a staged contrast never makes
+    // `huerotate` see a different pixel model. Guards the Codex adversarial review on #42.
+    let base = DynamicImage::ImageLumaA8(ImageBuffer::from_raw(1, 1, vec![120u8, 200]).unwrap());
+
+    let without = {
+      let mut img = base.clone();
+      let args = ImageTransformArgs {
+        huerotate: Some(90),
+        opacity: Some(1.0),
+        ..Default::default()
+      };
+      apply_transforms(&mut img, &args, None, true).unwrap();
+      img.to_rgba8().get_pixel(0, 0).0
+    };
+    let with_noop_contrast = {
+      let mut img = base.clone();
+      let args = ImageTransformArgs {
+        contrast: Some(0.0),
+        huerotate: Some(90),
+        opacity: Some(1.0),
+        ..Default::default()
+      };
+      apply_transforms(&mut img, &args, None, true).unwrap();
+      img.to_rgba8().get_pixel(0, 0).0
+    };
+    assert_eq!(
+      without, with_noop_contrast,
+      "a no-op contrast(0) must not change huerotate output (LumaA must not be promoted early)"
+    );
   }
 }

--- a/website/pages/docs/api.md
+++ b/website/pages/docs/api.md
@@ -102,6 +102,7 @@ Every transform mutates the pipeline and returns `this`, so they chain. They are
 | `adjustContrast(contrast)`                          | + increases contrast, − decreases.                                                       |
 | `brighten(brightness)`                              | + brightens, − darkens.                                                                  |
 | `huerotate(hue)`                                    | Rotate hue by degrees (0/360 are no-ops), like CSS `hue-rotate()`.                       |
+| `opacity(factor)`                                   | Multiply the alpha channel by `factor` (0–1), like CSS `opacity`. Keeps the bit depth.   |
 
 `resize` signature:
 


### PR DESCRIPTION
## What

Adds a chainable `Transformer.opacity(factor)` that multiplies the image's alpha channel by `factor` (`0..1`), like CSS `opacity`. `Closes #42`.

```js
// fade-out gif frames
for (const a of [1, 0.75, 0.5, 0.25, 0]) frames.push(await new Transformer(img).opacity(a).png())

// overlap two images without hiding the bottom — fade the TOP source, then overlay it
const ghost = await new Transformer(top).opacity(0.4).png()
await new Transformer(bottom).overlay(ghost, x, y).png()
```

## Why

Issue #42 bundled three asks; two already ship:

| Ask | Status |
| --- | --- |
| create an image from raw pixels | already exists — `Transformer.fromRgbaPixels` |
| overlap 2 images | already exists — `overlay` |
| **set an image's alpha (partial transparency)** | **this PR — `opacity(factor)`** |

sharp has no direct equivalent (`ensureAlpha` only sets alpha when none exists; a real fade needs `composite` + `dest-in`), so a single chainable `opacity(0..1)` fills a real gap.

## How

`opacity` is staged in `ImageTransformArgs` and applied lazily at encode time, exactly like every other filter (`grayscale`, `brighten`, …). Because it promotes the image to an alpha-capable type it is treated like `grayscale` for `metadata().colorType`.

Bit depth is **preserved** — `apply_opacity` branches to `RGBA8` / `RGBA16` / `RGBA32F` rather than always calling `to_rgba8()`, so 16-bit (e.g. 10-bit HEIC) and HDR float sources keep their precision even at `opacity(1)`. A non-finite `factor` is treated as identity (never silently zeroes alpha); factors are clamped to `0..1`.

### Note on `opacity` + `overlay`
Like every existing filter, `opacity` applies to *this* image's content; an `overlay` is composited on top **afterward** (overlay is the final compositing step). To fade an image you are dropping onto another, call `opacity` on the top image first, then pass it to the bottom image's `overlay` — see the docstring and the new test.

## Tests
- **5 Rust unit tests** — alpha math + bit-depth preservation across 8/16/32-bit, clamp `>1`, and NaN-is-identity.
- **6 ava tests** — alpha scaling, `opacity(0)`/`opacity(1)`, partial-alpha scaling, RGBA promotion in `metadata()`, and the #42 "overlap without hiding the bottom" recipe.

```
Rust: 128 passed   clippy clean
ava:   87 passed    2 skipped (pre-existing)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large changes to the shared transform pipeline (custom contrast/hue-rotate and opacity ordering) can alter RGBA/16-bit/HDR output versus prior crate behavior, though tests aim to preserve 8-bit color parity with the crate.
> 
> **Overview**
> Adds chainable **`Transformer.opacity(factor)`** (CSS-style alpha multiply, `0..1`, bit depth preserved) and wires it through the encode/metadata pipeline so **`metadata().colorType`** reflects RGBA promotion when opacity is staged.
> 
> To keep **`new = old * factor`** correct with other filters, the pipeline now uses **alpha-preserving** **`apply_contrast`** and **`apply_huerotate`** instead of the `image` crate’s versions (which mangled alpha and crushed 16-bit/HDR). **`apply_opacity`** runs after value/spatial filters so blur feathering is scaled, not overwritten. **AVIF** encoding for **16-bit and float RGBA** now converts to **RGBA8** so alpha is not dropped after `.opacity().avif()`.
> 
> **CI** gains a macOS **`cargo test -p napi_rs_image`** job (publish gate); **AVA** and **Rust unit tests** cover opacity, filter interaction, overlay fade, and depth/AVIF regressions. **Types and docs** document **`opacity`** on **`Transformer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68366db768796cdb3d33beaca91e76e98e78da88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->