### PR TITLE
feat(transformer): add composite() with sharp blend modes, gravity, tiling (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,5 @@ writeFileSync('output-debian.jpeg', await Transformer.fromSvg(SVG, 'rgba(238, 23
 
 console.info(chalk.green('Encoding jpeg from SVG done'))
 ```
+
+`composite()` uses W3C/CSS blend semantics (the same model as CSS `mix-blend-mode`, SVG, and Canvas) and matches sharp for opaque inputs and the default `Over` mode, differing only for translucent inputs combined with a separable blend mode (Multiply, Screen, HardLight, etc.).

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ HEVC codec — **ImageIO** on macOS, the **Windows Imaging Component (WIC)** on 
 the HEVC patent license. This means the package **ships no HEVC/HEIC codec** and incurs no codec
 licensing. On other platforms, HEIC decode and `.heic()` / `.heicSync()` reject with a clear error.
 
-> **Windows codec:** WIC's HEVC support comes from the OS *HEVC Video Extensions* / *HEIF Image
-> Extension* Store packages. They are absent on stock Windows Server / CI runners; on such a host
+> **Windows codec:** WIC's HEVC support comes from the OS _HEVC Video Extensions_ / _HEIF Image
+> Extension_ Store packages. They are absent on stock Windows Server / CI runners; on such a host
 > HEIC decode and encode reject with a clear "codec not installed" error.
 
 - **Decode:** reads `.heic` / `.heif` (HEVC-in-HEIF, e.g. iPhone photos). Image orientation (HEIF's
@@ -132,6 +132,8 @@ import {
   Transformer,
   ResizeFilterType,
   ChromaSubsampling,
+  BlendMode,
+  Gravity,
 } from '@napi-rs/image'
 import chalk from 'chalk'
 
@@ -194,6 +196,13 @@ console.info(chalk.green('Encoding webp from JPEG with EXIF done'))
 writeFileSync('output-overlay-png.png', await new Transformer(PNG).overlay(PNG, 200, 200).png())
 
 console.info(chalk.green('Overlay an image done'))
+
+writeFileSync(
+  'output-composite-png.png',
+  await new Transformer(PNG).composite(PNG, { gravity: Gravity.SouthEast, blend: BlendMode.Multiply }).png(),
+)
+
+console.info(chalk.green('Composite an image done'))
 
 writeFileSync('output-debian.jpeg', await Transformer.fromSvg(SVG, 'rgba(238, 235, 230, .9)').jpeg())
 

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -591,6 +591,17 @@ test('composite chains preserve intermediate alpha on an opaque base (#138)', as
   t.true(raw[1] > 200 && raw[0] < 60 && raw[2] < 60, `expected green at (0,0), got [${raw[0]},${raw[1]},${raw[2]}]`)
 })
 
+test('composite Dest preserves destination color stored under alpha 0 (#138)', async (t) => {
+  // Base carries non-black color under a fully-transparent alpha; Dest ignores the overlay, so
+  // those covered pixels must be preserved exactly (integer path parity with the f32 path).
+  const n = 8
+  const base = Uint8Array.from(Array.from({ length: n * n }, () => [200, 100, 50, 0]).flat())
+  const top = await Transformer.fromRgbaPixels(
+    Uint8Array.from(Array.from({ length: n * n }, () => [255, 255, 255, 255]).flat()), n, n).png()
+  const raw = await Transformer.fromRgbaPixels(base, n, n).composite(top, { left: 0, top: 0, blend: BlendMode.Dest }).rawPixels()
+  t.deepEqual(Array.from(raw.slice(0, 4)), [200, 100, 50, 0], `Dest must preserve color under alpha 0, got [${raw.slice(0,4)}]`)
+})
+
 test('composite alpha persists across an interleaved legacy overlay() on a no-alpha base (#138)', async (t) => {
   // Persistent-RGBA-across-the-whole-chain semantics (matches sharp's flatten-at-end model):
   // a DestOut hole survives a legacy overlay() and is still fillable by a later DestOver, instead

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -627,3 +627,19 @@ test('composite sanitizes NaN opacity to a full overlay (#138)', async (t) => {
   t.true(raw[2] <= 1, `blue fully covered; got ${raw[2]}`)
   t.is(raw[3], 255, 'opaque base stays opaque')
 })
+
+// sharp parity: composite() rejects an overlay larger than the base in either dimension, throwing
+// "Image to composite must have same dimensions or smaller". Legacy overlay() keeps its historical
+// silent clipping and must NOT throw on the same oversized top.
+test('composite rejects an oversized overlay while overlay() clips (#138)', async (t) => {
+  const base = Uint8Array.from(Array.from({ length: 2 * 2 }, () => [0, 0, 0, 255]).flat())
+  const top = Uint8Array.from(Array.from({ length: 4 * 4 }, () => [10, 20, 30, 255]).flat())
+  const topPng = await Transformer.fromRgbaPixels(top, 4, 4).png()
+  const err = await t.throwsAsync(() => Transformer.fromRgbaPixels(base, 2, 2).composite(topPng).png())
+  t.true(
+    /same dimensions or smaller/.test(err.message),
+    `oversized composite must report the sharp error; got ${err && err.message}`,
+  )
+  // Legacy overlay() with the same oversized top clips instead of throwing.
+  await t.notThrowsAsync(() => Transformer.fromRgbaPixels(base, 2, 2).overlay(topPng, 0, 0).png())
+})

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -587,3 +587,43 @@ test('composite opacity fades the overlay (#138)', async (t) => {
   t.true(raw[2] >= 127 && raw[2] <= 129, `remaining blue ~= 128; got ${raw[2]}`)
   t.is(raw[3], 255, 'opaque base stays opaque')
 })
+
+// sharp parity: with NO options the overlay anchors at the CENTRE of the base. A 2x2 top on a
+// 4x4 base lands at (1,1)..(2,2), so the centre pixel is painted and the corner is untouched.
+test('composite default placement is the centre of the base (#138)', async (t) => {
+  const base = Uint8Array.from(Array.from({ length: 4 * 4 }, () => [0, 0, 0, 255]).flat())
+  const top = Uint8Array.from(Array.from({ length: 2 * 2 }, () => [10, 20, 30, 255]).flat())
+  const topPng = await Transformer.fromRgbaPixels(top, 2, 2).png()
+  const raw = await Transformer.fromRgbaPixels(base, 4, 4).composite(topPng).rawPixels()
+  // centre pixel (2,2) -> offset (2*4+2)*4 = 40 carries the overlay color.
+  t.is(raw[40], 10)
+  t.is(raw[41], 20)
+  t.is(raw[42], 30)
+  t.is(raw[43], 255)
+  // corner (0,0) -> offset 0 stays the untouched base color.
+  t.is(raw[0], 0)
+  t.is(raw[1], 0)
+  t.is(raw[2], 0)
+  t.is(raw[3], 255)
+})
+
+// sharp parity: `left` and `top` must be provided together — supplying exactly one throws.
+test('composite throws when only one of left/top is set (#138)', async (t) => {
+  const top = Uint8Array.from([10, 20, 30, 255])
+  const topPng = await Transformer.fromRgbaPixels(top, 1, 1).png()
+  const base = Uint8Array.from([0, 0, 0, 255])
+  t.throws(() => Transformer.fromRgbaPixels(base, 1, 1).composite(topPng, { left: 1 }))
+  t.throws(() => Transformer.fromRgbaPixels(base, 1, 1).composite(topPng, { top: 1 }))
+})
+
+// A non-finite opacity is sanitized to 1.0 (identity), matching opacity()/apply_opacity — the
+// overlay applies in full instead of corrupting the result to black/NaN.
+test('composite sanitizes NaN opacity to a full overlay (#138)', async (t) => {
+  const blue = Uint8Array.from([0, 0, 255, 255])
+  const red = Uint8Array.from([255, 0, 0, 255])
+  const topPng = await Transformer.fromRgbaPixels(red, 1, 1).png()
+  const raw = await Transformer.fromRgbaPixels(blue, 1, 1).composite(topPng, { opacity: NaN }).rawPixels()
+  t.true(raw[0] >= 254, `NaN opacity -> full red overlay; got ${raw[0]}`)
+  t.true(raw[2] <= 1, `blue fully covered; got ${raw[2]}`)
+  t.is(raw[3], 255, 'opaque base stays opaque')
+})

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -591,6 +591,26 @@ test('composite chains preserve intermediate alpha on an opaque base (#138)', as
   t.true(raw[1] > 200 && raw[0] < 60 && raw[2] < 60, `expected green at (0,0), got [${raw[0]},${raw[1]},${raw[2]}]`)
 })
 
+test('composite alpha persists across an interleaved legacy overlay() on a no-alpha base (#138)', async (t) => {
+  // Persistent-RGBA-across-the-whole-chain semantics (matches sharp's flatten-at-end model):
+  // a DestOut hole survives a legacy overlay() and is still fillable by a later DestOver, instead
+  // of being flattened to opaque black between items. RGB8 (no-alpha) base from a JPEG decode.
+  const baseJpeg = await fs.readFile(join(ROOT_DIR, 'un-optimized.jpg'))
+  const fill = (n, c) => Uint8Array.from(Array.from({ length: n * n }, () => c).flat())
+  const opaque = await Transformer.fromRgbaPixels(fill(40, [10, 20, 30, 255]), 40, 40).png()
+  const red50 = await Transformer.fromRgbaPixels(fill(40, [255, 0, 0, 128]), 40, 40).png()
+  const green = await Transformer.fromRgbaPixels(fill(40, [0, 255, 0, 255]), 40, 40).png()
+  const raw = await new Transformer(baseJpeg)
+    .composite(opaque, { left: 0, top: 0, blend: BlendMode.DestOut })  // punch a transparent hole
+    .overlay(red50, 0, 0)                                              // legacy overlay sees the hole
+    .composite(green, { left: 0, top: 0, blend: BlendMode.DestOver })  // fills behind -> green shows
+    .rawPixels()
+  // Green must show through (DestOver filled the still-translucent area). The old per-item-flatten
+  // bug gave [128,0,0] (green lost). sharp gives ~[128,126,0]; allow tolerance.
+  t.true(raw[1] > 100, `expected green to persist through the chain, got [${raw[0]},${raw[1]},${raw[2]}]`)
+  t.true(raw[2] < 30, `blue should be ~0, got [${raw[0]},${raw[1]},${raw[2]}]`)
+})
+
 // composite() opacity fades the OVERLAY, so a 50%-faded red over blue blends to ~purple.
 test('composite opacity fades the overlay (#138)', async (t) => {
   const blue = Uint8Array.from([0, 0, 255, 255])

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -549,6 +549,21 @@ test('composite Gravity.SouthEast places the overlay bottom-right (#138)', async
   t.is(raw[3], 255)
 })
 
+test('composite clearing modes clear pixels outside a sub-base overlay (sharp parity #138)', async (t) => {
+  // sharp places the overlay on a full transparent canvas; DestIn keeps dest only where the overlay
+  // covers, clearing the rest to transparent. RGBA base so the output keeps alpha.
+  const W = 4, H = 4
+  const base = new Uint8Array(W * H * 4)
+  for (let i = 0; i < W * H; i++) { base.set([20 + i * 10, 200 - i * 8, 50 + i * 5, 255], i * 4) }
+  const overlay = await Transformer.fromRgbaPixels(Uint8Array.from([255, 255, 255, 255]), 1, 1).png()
+  const raw = await Transformer.fromRgbaPixels(base.slice(), W, H)
+    .composite(overlay, { left: 0, top: 0, blend: BlendMode.DestIn })
+    .rawPixels()
+  const at = (x, y) => Array.from(raw.slice((y * W + x) * 4, (y * W + x) * 4 + 4))
+  t.deepEqual(at(0, 0), [20, 200, 50, 255], 'covered pixel keeps the destination (DestIn)')
+  t.deepEqual(at(3, 3), [0, 0, 0, 0], 'uncovered pixel is cleared to transparent (matches sharp)')
+})
+
 // composite() with tile: true repeats the overlay across the whole base.
 test('composite tile covers the whole base (#138)', async (t) => {
   const base = Uint8Array.from(Array.from({ length: 4 * 4 }, () => [50, 60, 70, 255]).flat())

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -577,6 +577,20 @@ test('composite DestOver keeps the opaque backdrop (#138)', async (t) => {
   t.is(raw[3], 255)
 })
 
+test('composite chains preserve intermediate alpha on an opaque base (#138)', async (t) => {
+  // RGB8 (no-alpha) base from a JPEG decode
+  const baseJpeg = await fs.readFile(join(ROOT_DIR, 'un-optimized.jpg'))
+  const px = (n, c) => Uint8Array.from(Array.from({ length: n * n }, () => c).flat())
+  const red = await Transformer.fromRgbaPixels(px(40, [255, 0, 0, 255]), 40, 40).png()
+  const green = await Transformer.fromRgbaPixels(px(40, [0, 255, 0, 255]), 40, 40).png()
+  const raw = await new Transformer(baseJpeg)
+    .composite(red, { left: 0, top: 0, blend: BlendMode.DestOut })
+    .composite(green, { left: 0, top: 0, blend: BlendMode.DestOver })
+    .rawPixels()
+  // The DestOver fills the hole DestOut punched -> green, not flattened black.
+  t.true(raw[1] > 200 && raw[0] < 60 && raw[2] < 60, `expected green at (0,0), got [${raw[0]},${raw[1]},${raw[2]}]`)
+})
+
 // composite() opacity fades the OVERLAY, so a 50%-faded red over blue blends to ~purple.
 test('composite opacity fades the overlay (#138)', async (t) => {
   const blue = Uint8Array.from([0, 0, 255, 255])

--- a/packages/binding/__test__/transformer.spec.mjs
+++ b/packages/binding/__test__/transformer.spec.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url'
 import test from 'ava'
 import { decode } from 'blurhash'
 
-import { JsColorType, ResizeFit, Transformer } from '../index.js'
+import { BlendMode, Gravity, JsColorType, ResizeFit, Transformer } from '../index.js'
 
 const __DIRNAME = join(fileURLToPath(import.meta.url), '..')
 const ROOT_DIR = join(__DIRNAME, '..', '..', '..')
@@ -518,4 +518,72 @@ test('reuse: rotate metadata is stable across raw pixels + encode (#158)', async
   const after = transformer.metadataSync()
   t.is(after.width, upright.width, 'rotate applied once, not re-rotated by the prior encode')
   t.is(after.height, upright.height)
+})
+
+// composite() with a Multiply blend: two mid-grays multiply to ~quarter brightness.
+// 0.502^2 * 255 ≈ 64. Alpha stays fully opaque.
+test('composite Multiply halves two mid-grays (#138)', async (t) => {
+  const gray = Uint8Array.from([128, 128, 128, 255])
+  const topPng = await Transformer.fromRgbaPixels(gray, 1, 1).png()
+  const raw = await Transformer.fromRgbaPixels(gray, 1, 1).composite(topPng, { blend: BlendMode.Multiply }).rawPixels()
+  t.true(raw[0] >= 63 && raw[0] <= 65, `Multiply of two mid-grays ~= 64; got ${raw[0]}`)
+  t.is(raw[3], 255, 'opaque base stays opaque')
+})
+
+// composite() with Gravity.SouthEast anchors a small overlay at the bottom-right corner,
+// leaving the rest of the base untouched.
+test('composite Gravity.SouthEast places the overlay bottom-right (#138)', async (t) => {
+  const base = Uint8Array.from(Array.from({ length: 4 * 4 }, () => [0, 0, 0, 255]).flat())
+  const top = Uint8Array.from(Array.from({ length: 2 * 2 }, () => [10, 20, 30, 255]).flat())
+  const topPng = await Transformer.fromRgbaPixels(top, 2, 2).png()
+  const raw = await Transformer.fromRgbaPixels(base, 4, 4).composite(topPng, { gravity: Gravity.SouthEast }).rawPixels()
+  // bottom-right pixel (3,3) -> offset (3*4+3)*4 = 60 carries the overlay color.
+  t.is(raw[60], 10)
+  t.is(raw[61], 20)
+  t.is(raw[62], 30)
+  t.is(raw[63], 255)
+  // top-left pixel (0,0) -> offset 0 is untouched base color.
+  t.is(raw[0], 0)
+  t.is(raw[1], 0)
+  t.is(raw[2], 0)
+  t.is(raw[3], 255)
+})
+
+// composite() with tile: true repeats the overlay across the whole base.
+test('composite tile covers the whole base (#138)', async (t) => {
+  const base = Uint8Array.from(Array.from({ length: 4 * 4 }, () => [50, 60, 70, 255]).flat())
+  const top = Uint8Array.from(Array.from({ length: 2 * 2 }, () => [10, 20, 30, 255]).flat())
+  const topPng = await Transformer.fromRgbaPixels(top, 2, 2).png()
+  const raw = await Transformer.fromRgbaPixels(base, 4, 4).composite(topPng, { tile: true }).rawPixels()
+  for (let i = 0; i < 16; i++) {
+    const o = i * 4
+    t.is(raw[o], 10, `pixel ${i} R`)
+    t.is(raw[o + 1], 20, `pixel ${i} G`)
+    t.is(raw[o + 2], 30, `pixel ${i} B`)
+    t.is(raw[o + 3], 255, `pixel ${i} A`)
+  }
+})
+
+// composite() with BlendMode.DestOver keeps the (opaque) backdrop: Fa = 1 - ab = 0,
+// so the base shows through unchanged.
+test('composite DestOver keeps the opaque backdrop (#138)', async (t) => {
+  const red = Uint8Array.from([255, 0, 0, 255])
+  const blue = Uint8Array.from([0, 0, 255, 255])
+  const topPng = await Transformer.fromRgbaPixels(blue, 1, 1).png()
+  const raw = await Transformer.fromRgbaPixels(red, 1, 1).composite(topPng, { blend: BlendMode.DestOver }).rawPixels()
+  t.is(raw[0], 255)
+  t.is(raw[1], 0)
+  t.is(raw[2], 0)
+  t.is(raw[3], 255)
+})
+
+// composite() opacity fades the OVERLAY, so a 50%-faded red over blue blends to ~purple.
+test('composite opacity fades the overlay (#138)', async (t) => {
+  const blue = Uint8Array.from([0, 0, 255, 255])
+  const red = Uint8Array.from([255, 0, 0, 255])
+  const topPng = await Transformer.fromRgbaPixels(red, 1, 1).png()
+  const raw = await Transformer.fromRgbaPixels(blue, 1, 1).composite(topPng, { opacity: 0.5 }).rawPixels()
+  t.true(raw[0] >= 127 && raw[0] <= 129, `faded red ~= 128; got ${raw[0]}`)
+  t.true(raw[2] >= 127 && raw[2] <= 129, `remaining blue ~= 128; got ${raw[2]}`)
+  t.is(raw[3], 255, 'opaque base stays opaque')
 })

--- a/packages/binding/image.wasi-browser.js
+++ b/packages/binding/image.wasi-browser.js
@@ -58,12 +58,14 @@ const {
 })
 export default __napiModule.exports
 export const Transformer = __napiModule.exports.Transformer
+export const BlendMode = __napiModule.exports.BlendMode
 export const ChromaSubsampling = __napiModule.exports.ChromaSubsampling
 export const CompressionType = __napiModule.exports.CompressionType
 export const compressJpeg = __napiModule.exports.compressJpeg
 export const compressJpegSync = __napiModule.exports.compressJpegSync
 export const FastResizeFilter = __napiModule.exports.FastResizeFilter
 export const FilterType = __napiModule.exports.FilterType
+export const Gravity = __napiModule.exports.Gravity
 export const JsColorType = __napiModule.exports.JsColorType
 export const losslessCompressPng = __napiModule.exports.losslessCompressPng
 export const losslessCompressPngSync = __napiModule.exports.losslessCompressPngSync

--- a/packages/binding/image.wasi.cjs
+++ b/packages/binding/image.wasi.cjs
@@ -109,12 +109,14 @@ const { instance: __napiInstance, module: __wasiModule, napiModule: __napiModule
 })
 module.exports = __napiModule.exports
 module.exports.Transformer = __napiModule.exports.Transformer
+module.exports.BlendMode = __napiModule.exports.BlendMode
 module.exports.ChromaSubsampling = __napiModule.exports.ChromaSubsampling
 module.exports.CompressionType = __napiModule.exports.CompressionType
 module.exports.compressJpeg = __napiModule.exports.compressJpeg
 module.exports.compressJpegSync = __napiModule.exports.compressJpegSync
 module.exports.FastResizeFilter = __napiModule.exports.FastResizeFilter
 module.exports.FilterType = __napiModule.exports.FilterType
+module.exports.Gravity = __napiModule.exports.Gravity
 module.exports.JsColorType = __napiModule.exports.JsColorType
 module.exports.losslessCompressPng = __napiModule.exports.losslessCompressPng
 module.exports.losslessCompressPngSync = __napiModule.exports.losslessCompressPngSync

--- a/packages/binding/index.d.ts
+++ b/packages/binding/index.d.ts
@@ -99,14 +99,22 @@ export declare class Transformer {
    *
    * Placement (sharp parity): when neither `left` nor `top` is given the overlay is
    * anchored by `gravity`, which defaults to the CENTRE of the base image. `left` and
-   * `top` must be provided together — supplying only one is an error.
+   * `top` must be provided together — supplying only one is an error. The overlay must be
+   * the same size as the base or smaller in both dimensions; a larger overlay is an error
+   * (`Image to composite must have same dimensions or smaller`). When `tile` is set the
+   * overlay repeats to fill the whole base, phased so one tile aligns with the resolved
+   * `left`/`top` or `gravity`.
    *
-   * Source-over (`blend: Over`, no tiling, full opacity) composites at 8-bit, identical
-   * to `overlay`. Other blend modes / tiling / opacity < 1 run at the base image's native
-   * channel depth (8/16-bit, or 32-bit float), then the result is converted back to the
-   * base's original color type — so an opaque base never gains an alpha channel. On an
-   * opaque base, coverage-reducing modes (Clear/Out/DestOut/Xor) flatten the overlapped
-   * region toward black, since the removed alpha can't be stored without an alpha channel.
+   * `composite()` always composites at the base image's native channel depth (8/16-bit, or
+   * 32-bit float), then converts the result back to the base's original color type — so an
+   * opaque base never gains an alpha channel. (Even a default `Over` runs through this depth-
+   * aware path; its 8-bit output may differ from `overlay`'s by at most 1 per channel due to
+   * rounding vs truncation.) On an opaque base, coverage-reducing modes (Clear/Out/DestOut/Xor)
+   * flatten the overlapped region toward black, since the removed alpha can't be stored without
+   * an alpha channel. For 32-bit-float (HDR) bases, blend-mode compositing operates in `[0,1]`
+   * (where the W3C blend modes are defined), so HDR channel values outside `[0,1]` in the
+   * composited region are clamped; fully-transparent sources, `Dest`, and `DestOver` over an
+   * opaque backdrop are preserved exactly.
    */
   composite(onTop: Uint8Array, options?: CompositeOptions | undefined | null): this
   /** Return this image's pixels as a native endian byte slice. */
@@ -294,7 +302,10 @@ export interface CompositeOptions {
   gravity?: Gravity
   /** Blend / compositing operator. Defaults to `Over` (source-over). */
   blend?: BlendMode
-  /** Repeat the overlay to tile across the whole base. Ignores `left`/`top`/`gravity`. */
+  /**
+   * Repeat the overlay to fill the whole base, phased so a tile aligns with the resolved
+   * `left`/`top` or `gravity`.
+   */
   tile?: boolean
   /**
    * Multiply the overlay's alpha by this factor (0.0..=1.0). Fades the OVERLAY

--- a/packages/binding/index.d.ts
+++ b/packages/binding/index.d.ts
@@ -115,6 +115,12 @@ export declare class Transformer {
    * (where the W3C blend modes are defined), so HDR channel values outside `[0,1]` in the
    * composited region are clamped; fully-transparent sources, `Dest`, and `DestOver` over an
    * opaque backdrop are preserved exactly.
+   *
+   * Blending follows the W3C "Compositing and Blending Level 1" model (the same one used by CSS
+   * `mix-blend-mode`, SVG, and Canvas). Results match sharp/libvips for opaque inputs and for
+   * `Over` at any alpha; for a translucent source or backdrop combined with a separable blend mode
+   * (Multiply, Screen, HardLight, etc.), per-pixel values differ from sharp, which uses
+   * premultiplied-alpha math.
    */
   composite(onTop: Uint8Array, options?: CompositeOptions | undefined | null): this
   /** Return this image's pixels as a native endian byte slice. */

--- a/packages/binding/index.d.ts
+++ b/packages/binding/index.d.ts
@@ -26,7 +26,12 @@ export declare class Transformer {
    * The image is scaled to the maximum possible size that fits
    * within the bounds specified by `width` and `height`.
    */
-  resize(widthOrOptions: number | ResizeOptions, height?: number | undefined | null, filter?: ResizeFilterType | undefined | null, fit?: ResizeFit | undefined | null): this
+  resize(
+    widthOrOptions: number | ResizeOptions,
+    height?: number | undefined | null,
+    filter?: ResizeFilterType | undefined | null,
+    fit?: ResizeFit | undefined | null,
+  ): this
   /**
    * Resize this image using the specified filter algorithm.
    * The image is scaled to the maximum possible size that fits
@@ -86,8 +91,20 @@ export declare class Transformer {
   opacity(factor: number): this
   /** Crop a cut-out of this image delimited by the bounding rectangle. */
   crop(x: number, y: number, width: number, height: number): this
-  /** Overlay an image at a given coordinate (x, y) */
+  /** Overlay an image at a given coordinate (x, y) using source-over blending. */
   overlay(onTop: Uint8Array, x: number, y: number): this
+  /**
+   * Composite `on_top` onto this image with a sharp-style blend mode, gravity-based
+   * positioning, tiling, and per-overlay opacity. See `CompositeOptions`.
+   *
+   * Source-over (`blend: Over`, no tiling, full opacity) composites at 8-bit, identical
+   * to `overlay`. Other blend modes / tiling / opacity < 1 run at the base image's native
+   * channel depth (8/16-bit, or 32-bit float), then the result is converted back to the
+   * base's original color type — so an opaque base never gains an alpha channel. On an
+   * opaque base, coverage-reducing modes (Clear/Out/DestOut/Xor) flatten the overlapped
+   * region toward black, since the removed alpha can't be stored without an alpha channel.
+   */
+  composite(onTop: Uint8Array, options?: CompositeOptions | undefined | null): this
   /** Return this image's pixels as a native endian byte slice. */
   rawPixels(signal?: AbortSignal | undefined | null): Promise<Buffer>
   /** Return this image's pixels as a native endian byte slice. */
@@ -156,6 +173,63 @@ export interface AvifConfig {
 }
 
 /**
+ * Compositing / blending operator for `Transformer.composite`. Mirrors sharp/libvips
+ * blend modes: Porter-Duff operators plus the W3C separable blend modes.
+ */
+export declare enum BlendMode {
+  /** Source-over (default) — the overlay is drawn on top of the base. */
+  Over = 0,
+  /** Clear — neither source nor destination is shown. */
+  Clear = 1,
+  /** Source — only the overlay is shown. */
+  Source = 2,
+  /** Source-in — the overlay clipped to the base's shape. */
+  In = 3,
+  /** Source-out — the overlay where the base is transparent. */
+  Out = 4,
+  /** Source-atop — the overlay drawn only where the base is opaque. */
+  Atop = 5,
+  /** Destination — only the base is shown (overlay ignored). */
+  Dest = 6,
+  /** Destination-over — the base drawn on top of the overlay. */
+  DestOver = 7,
+  /** Destination-in — the base clipped to the overlay's shape. */
+  DestIn = 8,
+  /** Destination-out — the base where the overlay is transparent. */
+  DestOut = 9,
+  /** Destination-atop — the base drawn only where the overlay is opaque. */
+  DestAtop = 10,
+  /** Exclusive-or of the two coverage regions. */
+  Xor = 11,
+  /** Additive blending. */
+  Add = 12,
+  /** Saturating additive blending. */
+  Saturate = 13,
+  /** Multiply the channels. */
+  Multiply = 14,
+  /** Screen (inverse-multiply) the channels. */
+  Screen = 15,
+  /** Overlay (multiply or screen depending on the backdrop). */
+  Overlay = 16,
+  /** Keep the darker of the two channels. */
+  Darken = 17,
+  /** Keep the lighter of the two channels. */
+  Lighten = 18,
+  /** Brighten the backdrop to reflect the source. */
+  ColorDodge = 19,
+  /** Darken the backdrop to reflect the source. */
+  ColorBurn = 20,
+  /** Hard light (overlay with swapped operands). */
+  HardLight = 21,
+  /** Soft light. */
+  SoftLight = 22,
+  /** Absolute difference of the channels. */
+  Difference = 23,
+  /** Like difference but with lower contrast. */
+  Exclusion = 24,
+}
+
+/**
  * https://en.wikipedia.org/wiki/Chroma_subsampling#Types_of_sampling_and_subsampling
  * https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_concepts
  */
@@ -195,7 +269,25 @@ export declare enum ChromaSubsampling {
    * What if the chroma subsampling model is 4:0:0?
    * That says to use every pixel of luma data, but that each row has 0 chroma samples applied to it. The resulting image, then, is comprised solely of the luminance data—a greyscale image.
    */
-  Yuv400 = 3
+  Yuv400 = 3,
+}
+
+export interface CompositeOptions {
+  /** Pixel offset from the top edge. Takes precedence over `gravity` when set. */
+  top?: number
+  /** Pixel offset from the left edge. Takes precedence over `gravity` when set. */
+  left?: number
+  /** Anchor position; used only when neither `left` nor `top` is provided. */
+  gravity?: Gravity
+  /** Blend / compositing operator. Defaults to `Over` (source-over). */
+  blend?: BlendMode
+  /** Repeat the overlay to tile across the whole base. Ignores `left`/`top`/`gravity`. */
+  tile?: boolean
+  /**
+   * Multiply the overlay's alpha by this factor (0.0..=1.0). Fades the OVERLAY
+   * (distinct from `Transformer.opacity`, which fades the base).
+   */
+  opacity?: number
 }
 
 export declare enum CompressionType {
@@ -204,10 +296,14 @@ export declare enum CompressionType {
   /** Fast, minimal compression */
   Fast = 1,
   /** High compression level */
-  Best = 2
+  Best = 2,
 }
 
-export declare function compressJpeg(input: Uint8Array, options?: JpegCompressOptions | undefined | null, signal?: AbortSignal | undefined | null): Promise<Buffer>
+export declare function compressJpeg(
+  input: Uint8Array,
+  options?: JpegCompressOptions | undefined | null,
+  signal?: AbortSignal | undefined | null,
+): Promise<Buffer>
 
 export declare function compressJpegSync(input: Uint8Array, options?: JpegCompressOptions | undefined | null): Buffer
 
@@ -248,7 +344,7 @@ export declare enum FastResizeFilter {
    * Lanczos filter (a truncated sinc) on all pixels that may contribute
    * to the output value.
    */
-  Lanczos3 = 5
+  Lanczos3 = 5,
 }
 
 export interface FastResizeOptions {
@@ -276,7 +372,32 @@ export declare enum FilterType {
    * Uses a heuristic to select one of the preceding filters for each
    * scanline rather than one filter for the entire image
    */
-  Adaptive = 5
+  Adaptive = 5,
+}
+
+/**
+ * Where to anchor the overlay relative to the base image when no explicit
+ * `left`/`top` is given.
+ */
+export declare enum Gravity {
+  /** Center of the base image. */
+  Center = 0,
+  /** Top edge, horizontally centered. */
+  North = 1,
+  /** Top-right corner. */
+  NorthEast = 2,
+  /** Right edge, vertically centered. */
+  East = 3,
+  /** Bottom-right corner. */
+  SouthEast = 4,
+  /** Bottom edge, horizontally centered. */
+  South = 5,
+  /** Bottom-left corner. */
+  SouthWest = 6,
+  /** Left edge, vertically centered. */
+  West = 7,
+  /** Top-left corner. */
+  NorthWest = 8,
 }
 
 /**
@@ -337,10 +458,14 @@ export declare enum JsColorType {
   /** Pixel is 32-bit float RGB */
   Rgb32F = 8,
   /** Pixel is 32-bit float RGBA */
-  Rgba32F = 9
+  Rgba32F = 9,
 }
 
-export declare function losslessCompressPng(input: Uint8Array, options?: PNGLosslessOptions | undefined | null, signal?: AbortSignal | undefined | null): Promise<Buffer>
+export declare function losslessCompressPng(
+  input: Uint8Array,
+  options?: PNGLosslessOptions | undefined | null,
+  signal?: AbortSignal | undefined | null,
+): Promise<Buffer>
 
 export declare function losslessCompressPngSync(input: Buffer, options?: PNGLosslessOptions | undefined | null): Buffer
 
@@ -362,7 +487,7 @@ export declare enum Orientation {
   MirrorHorizontalAndRotate270Cw = 5,
   Rotate90Cw = 6,
   MirrorHorizontalAndRotate90Cw = 7,
-  Rotate270Cw = 8
+  Rotate270Cw = 8,
 }
 
 export interface PngEncodeOptions {
@@ -415,7 +540,11 @@ export interface PNGLosslessOptions {
   strip?: boolean
 }
 
-export declare function pngQuantize(input: Uint8Array, options?: PngQuantOptions | undefined | null, signal?: AbortSignal | undefined | null): Promise<Buffer>
+export declare function pngQuantize(
+  input: Uint8Array,
+  options?: PngQuantOptions | undefined | null,
+  signal?: AbortSignal | undefined | null,
+): Promise<Buffer>
 
 export declare function pngQuantizeSync(input: Uint8Array, options?: PngQuantOptions | undefined | null): Buffer
 
@@ -442,7 +571,7 @@ export declare enum PngRowFilter {
   Sub = 1,
   Up = 2,
   Average = 3,
-  Paeth = 4
+  Paeth = 4,
 }
 
 /**
@@ -523,7 +652,7 @@ export declare enum ResizeFilterType {
   /** Gaussian Filter */
   Gaussian = 3,
   /** Lanczos with window 3 */
-  Lanczos3 = 4
+  Lanczos3 = 4,
 }
 
 export declare enum ResizeFit {
@@ -538,7 +667,7 @@ export declare enum ResizeFit {
    * Preserving aspect ratio
    * resize the image to be as large as possible while ensuring its dimensions are less than or equal to both those specified.
    */
-  Inside = 2
+  Inside = 2,
 }
 
 export interface ResizeOptions {

--- a/packages/binding/index.d.ts
+++ b/packages/binding/index.d.ts
@@ -97,6 +97,10 @@ export declare class Transformer {
    * Composite `on_top` onto this image with a sharp-style blend mode, gravity-based
    * positioning, tiling, and per-overlay opacity. See `CompositeOptions`.
    *
+   * Placement (sharp parity): when neither `left` nor `top` is given the overlay is
+   * anchored by `gravity`, which defaults to the CENTRE of the base image. `left` and
+   * `top` must be provided together — supplying only one is an error.
+   *
    * Source-over (`blend: Over`, no tiling, full opacity) composites at 8-bit, identical
    * to `overlay`. Other blend modes / tiling / opacity < 1 run at the base image's native
    * channel depth (8/16-bit, or 32-bit float), then the result is converted back to the
@@ -273,11 +277,20 @@ export declare enum ChromaSubsampling {
 }
 
 export interface CompositeOptions {
-  /** Pixel offset from the top edge. Takes precedence over `gravity` when set. */
+  /**
+   * Pixel offset from the top edge. Provide both `top` and `left` together;
+   * supplying only one is an error. When set, takes precedence over `gravity`.
+   */
   top?: number
-  /** Pixel offset from the left edge. Takes precedence over `gravity` when set. */
+  /**
+   * Pixel offset from the left edge. Provide both `left` and `top` together;
+   * supplying only one is an error. When set, takes precedence over `gravity`.
+   */
   left?: number
-  /** Anchor position; used only when neither `left` nor `top` is provided. */
+  /**
+   * Anchor position. Defaults to `Center`; used only when neither `left` nor
+   * `top` is set.
+   */
   gravity?: Gravity
   /** Blend / compositing operator. Defaults to `Over` (source-over). */
   blend?: BlendMode

--- a/packages/binding/index.js
+++ b/packages/binding/index.js
@@ -77,8 +77,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-android-arm64')
         const bindingPackageVersion = require('@napi-rs/image-android-arm64/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -93,8 +93,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-android-arm-eabi')
         const bindingPackageVersion = require('@napi-rs/image-android-arm-eabi/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -114,8 +114,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-win32-x64-gnu')
         const bindingPackageVersion = require('@napi-rs/image-win32-x64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -130,8 +130,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-win32-x64-msvc')
         const bindingPackageVersion = require('@napi-rs/image-win32-x64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -147,8 +147,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-win32-ia32-msvc')
         const bindingPackageVersion = require('@napi-rs/image-win32-ia32-msvc/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -163,8 +163,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-win32-arm64-msvc')
         const bindingPackageVersion = require('@napi-rs/image-win32-arm64-msvc/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -182,8 +182,8 @@ function requireNative() {
     try {
       const binding = require('@napi-rs/image-darwin-universal')
       const bindingPackageVersion = require('@napi-rs/image-darwin-universal/package.json').version
-      if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-        throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+      if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+        throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
       }
       return binding
     } catch (e) {
@@ -198,8 +198,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-darwin-x64')
         const bindingPackageVersion = require('@napi-rs/image-darwin-x64/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -214,8 +214,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-darwin-arm64')
         const bindingPackageVersion = require('@napi-rs/image-darwin-arm64/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -234,8 +234,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-freebsd-x64')
         const bindingPackageVersion = require('@napi-rs/image-freebsd-x64/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -250,8 +250,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-freebsd-arm64')
         const bindingPackageVersion = require('@napi-rs/image-freebsd-arm64/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -271,8 +271,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-x64-musl')
           const bindingPackageVersion = require('@napi-rs/image-linux-x64-musl/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -287,8 +287,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-x64-gnu')
           const bindingPackageVersion = require('@napi-rs/image-linux-x64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -305,8 +305,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-arm64-musl')
           const bindingPackageVersion = require('@napi-rs/image-linux-arm64-musl/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -321,8 +321,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-arm64-gnu')
           const bindingPackageVersion = require('@napi-rs/image-linux-arm64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -339,8 +339,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-arm-musleabihf')
           const bindingPackageVersion = require('@napi-rs/image-linux-arm-musleabihf/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -355,8 +355,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-arm-gnueabihf')
           const bindingPackageVersion = require('@napi-rs/image-linux-arm-gnueabihf/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -373,8 +373,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-loong64-musl')
           const bindingPackageVersion = require('@napi-rs/image-linux-loong64-musl/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -389,8 +389,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-loong64-gnu')
           const bindingPackageVersion = require('@napi-rs/image-linux-loong64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -407,8 +407,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-riscv64-musl')
           const bindingPackageVersion = require('@napi-rs/image-linux-riscv64-musl/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -423,8 +423,8 @@ function requireNative() {
         try {
           const binding = require('@napi-rs/image-linux-riscv64-gnu')
           const bindingPackageVersion = require('@napi-rs/image-linux-riscv64-gnu/package.json').version
-          if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-            throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+          if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+            throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
           }
           return binding
         } catch (e) {
@@ -440,8 +440,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-linux-ppc64-gnu')
         const bindingPackageVersion = require('@napi-rs/image-linux-ppc64-gnu/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -456,8 +456,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-linux-s390x-gnu')
         const bindingPackageVersion = require('@napi-rs/image-linux-s390x-gnu/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -476,8 +476,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-openharmony-arm64')
         const bindingPackageVersion = require('@napi-rs/image-openharmony-arm64/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -492,8 +492,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-openharmony-x64')
         const bindingPackageVersion = require('@napi-rs/image-openharmony-x64/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -508,8 +508,8 @@ function requireNative() {
       try {
         const binding = require('@napi-rs/image-openharmony-arm')
         const bindingPackageVersion = require('@napi-rs/image-openharmony-arm/package.json').version
-        if (bindingPackageVersion !== '1.13.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
-          throw new Error(`Native binding package version mismatch, expected 1.13.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
+        if (bindingPackageVersion !== '1.14.0' && process.env.NAPI_RS_ENFORCE_VERSION_CHECK && process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== '0') {
+          throw new Error(`Native binding package version mismatch, expected 1.14.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`)
         }
         return binding
       } catch (e) {
@@ -588,12 +588,14 @@ if (!nativeBinding) {
 
 module.exports = nativeBinding
 module.exports.Transformer = nativeBinding.Transformer
+module.exports.BlendMode = nativeBinding.BlendMode
 module.exports.ChromaSubsampling = nativeBinding.ChromaSubsampling
 module.exports.CompressionType = nativeBinding.CompressionType
 module.exports.compressJpeg = nativeBinding.compressJpeg
 module.exports.compressJpegSync = nativeBinding.compressJpegSync
 module.exports.FastResizeFilter = nativeBinding.FastResizeFilter
 module.exports.FilterType = nativeBinding.FilterType
+module.exports.Gravity = nativeBinding.Gravity
 module.exports.JsColorType = nativeBinding.JsColorType
 module.exports.losslessCompressPng = nativeBinding.losslessCompressPng
 module.exports.losslessCompressPngSync = nativeBinding.losslessCompressPngSync

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -595,7 +595,8 @@ pub struct CompositeOptions {
   pub gravity: Option<Gravity>,
   /// Blend / compositing operator. Defaults to `Over` (source-over).
   pub blend: Option<BlendMode>,
-  /// Repeat the overlay to tile across the whole base. Ignores `left`/`top`/`gravity`.
+  /// Repeat the overlay to fill the whole base, phased so a tile aligns with the resolved
+  /// `left`/`top` or `gravity`.
   pub tile: Option<bool>,
   /// Multiply the overlay's alpha by this factor (0.0..=1.0). Fades the OVERLAY
   /// (distinct from `Transformer.opacity`, which fades the base).
@@ -614,7 +615,8 @@ struct CompositeItem {
   gravity: Gravity, // used only when !has_offset; defaults to Center
   blend: BlendMode,
   tile: bool,
-  opacity: f32, // 1.0 == no-op
+  opacity: f32,         // 1.0 == no-op
+  simple_overlay: bool, // legacy overlay(): byte-identical 8-bit `image::overlay`; composite() => false
 }
 
 #[derive(Default, Clone)]
@@ -857,6 +859,17 @@ impl Task for EncodeTask {
       for item in std::mem::take(&mut self.image_transform_args.overlay).into_iter() {
         let top = ThreadsafeDynamicImage::new(item.buffer.clone());
         let top_image_meta = top.get(true)?;
+        // Fix D: composite() rejects an overlay larger than the base in either dimension (sharp
+        // parity). Legacy overlay() keeps its historical silent clipping.
+        if !item.simple_overlay {
+          let (tw, th) = (top_image_meta.image.width(), top_image_meta.image.height());
+          if tw > img.width() || th > img.height() {
+            return Err(Error::new(
+              Status::InvalidArg,
+              "Image to composite must have same dimensions or smaller".to_owned(),
+            ));
+          }
+        }
         let (x, y) = resolve_position(
           item.has_offset,
           item.left,
@@ -867,11 +880,12 @@ impl Task for EncodeTask {
           top_image_meta.image.width(),
           top_image_meta.image.height(),
         );
-        // Source-over with no tiling / full opacity keeps the fast 8-bit path (unchanged
-        // behaviour, byte-identical to `overlay`). Everything else uses the precise compositor.
-        if item.blend == BlendMode::Over && !item.tile && item.opacity == 1.0 {
+        if item.simple_overlay {
+          // Legacy overlay(): byte-identical 8-bit source-over (clips oversized overlays).
           overlay(&mut img, &top_image_meta.image, x, y);
         } else {
+          // composite(): always depth-aware at the base's native depth (8/16-bit or f32), so a
+          // default `Over` on an HDR base is not clamped to 8-bit and no-op guards apply.
           apply_composite(
             &mut img,
             &top_image_meta.image,
@@ -1336,6 +1350,7 @@ impl Transformer {
       blend: BlendMode::Over,
       tile: false,
       opacity: 1.0,
+      simple_overlay: true, // legacy: keep the byte-identical 8-bit `image::overlay` path
     });
     Ok(self)
   }
@@ -1346,14 +1361,22 @@ impl Transformer {
   ///
   /// Placement (sharp parity): when neither `left` nor `top` is given the overlay is
   /// anchored by `gravity`, which defaults to the CENTRE of the base image. `left` and
-  /// `top` must be provided together — supplying only one is an error.
+  /// `top` must be provided together — supplying only one is an error. The overlay must be
+  /// the same size as the base or smaller in both dimensions; a larger overlay is an error
+  /// (`Image to composite must have same dimensions or smaller`). When `tile` is set the
+  /// overlay repeats to fill the whole base, phased so one tile aligns with the resolved
+  /// `left`/`top` or `gravity`.
   ///
-  /// Source-over (`blend: Over`, no tiling, full opacity) composites at 8-bit, identical
-  /// to `overlay`. Other blend modes / tiling / opacity < 1 run at the base image's native
-  /// channel depth (8/16-bit, or 32-bit float), then the result is converted back to the
-  /// base's original color type — so an opaque base never gains an alpha channel. On an
-  /// opaque base, coverage-reducing modes (Clear/Out/DestOut/Xor) flatten the overlapped
-  /// region toward black, since the removed alpha can't be stored without an alpha channel.
+  /// `composite()` always composites at the base image's native channel depth (8/16-bit, or
+  /// 32-bit float), then converts the result back to the base's original color type — so an
+  /// opaque base never gains an alpha channel. (Even a default `Over` runs through this depth-
+  /// aware path; its 8-bit output may differ from `overlay`'s by at most 1 per channel due to
+  /// rounding vs truncation.) On an opaque base, coverage-reducing modes (Clear/Out/DestOut/Xor)
+  /// flatten the overlapped region toward black, since the removed alpha can't be stored without
+  /// an alpha channel. For 32-bit-float (HDR) bases, blend-mode compositing operates in `[0,1]`
+  /// (where the W3C blend modes are defined), so HDR channel values outside `[0,1]` in the
+  /// composited region are clamped; fully-transparent sources, `Dest`, and `DestOver` over an
+  /// opaque backdrop are preserved exactly.
   pub fn composite(
     &mut self,
     on_top: Uint8Array,
@@ -1385,6 +1408,7 @@ impl Transformer {
       blend: o.blend.unwrap_or_default(),
       tile: o.tile.unwrap_or(false),
       opacity,
+      simple_overlay: false, // composite() is always depth-aware (see compute() dispatch)
     });
     Ok(self)
   }
@@ -1938,6 +1962,7 @@ fn apply_opacity(image: &mut DynamicImage, factor: f32) {
 /// given (`has_offset`), `left`/`top` are used verbatim; otherwise the overlay is anchored by
 /// `gravity` (default Center). Computed in i64; negative results are valid (the overlay is
 /// clipped by the compositor).
+#[allow(clippy::too_many_arguments)] // placement primitives kept flat so the fn is unit-testable
 fn resolve_position(
   has_offset: bool,
   left: i64,
@@ -2142,10 +2167,12 @@ fn overlap_bounds(
   )
 }
 
-/// Invoke `f(ox, oy)` for each placement: once at `(x, y)` normally; for tiling, at every
-/// top-left origin stepping by the overlay size across the whole base from `(0,0)` (ignoring x/y).
-/// Streams the origins instead of materializing a `Vec` — a 1x1 tile over a large base would
-/// otherwise allocate one tuple per pixel.
+/// Invoke `f(ox, oy)` for each placement: once at `(x, y)` normally; for tiling, at every top-left
+/// origin stepping by the overlay size across the whole base. The tile grid is PHASED by the
+/// resolved `(x, y)` (from `left`/`top` or `gravity`) so one tile origin lands exactly on `(x, y)`
+/// and the rest tile outward to fill the base. Streams the origins instead of materializing a `Vec`
+/// — a 1x1 tile over a large base would otherwise allocate one tuple per pixel.
+#[allow(clippy::too_many_arguments)] // geometry primitives kept flat (bw/bh/tw/th/x/y) for clarity
 fn for_each_placement(
   tile: bool,
   bw: u32,
@@ -2164,14 +2191,18 @@ fn for_each_placement(
   if tw == 0 || th == 0 {
     return;
   }
-  let mut oy = 0u32;
-  while oy < bh {
-    let mut ox = 0u32;
-    while ox < bw {
-      f(ox as i64, oy as i64);
-      ox += tw;
+  let (tw_i, th_i) = (tw as i64, th as i64);
+  // First origin <= 0 congruent to the resolved (x, y) modulo tile size, so one tile lands on (x, y).
+  let start_x = x.rem_euclid(tw_i) - tw_i;
+  let start_y = y.rem_euclid(th_i) - th_i;
+  let mut oy = start_y;
+  while oy < bh as i64 {
+    let mut ox = start_x;
+    while ox < bw as i64 {
+      f(ox, oy);
+      ox += tw_i;
     }
-    oy += th;
+    oy += th_i;
   }
 }
 
@@ -2275,9 +2306,11 @@ fn composite_into_u16(
   });
 }
 
-/// Composite `top` onto a 32-bit float RGBA `base` in place. Channels are clamped to `[0,1]` for
-/// blending (HDR values outside the unit range are clamped, NaN sanitized to 0.0); the blended
-/// result is already clamped to `[0,1]`, so it is written directly.
+/// Composite `top` onto a 32-bit float RGBA `base` in place. The W3C blend modes are defined in
+/// `[0,1]`, so channels are clamped to `[0,1]` for blending (HDR values outside the unit range are
+/// clamped, NaN sanitized to 0.0) and the already-`[0,1]` result is written directly. To avoid
+/// clamping HDR/NaN destinations needlessly, destination-preserving cases (`Dest`, a transparent
+/// no-op source, and `DestOver` over an opaque backdrop) skip the pixel and keep the raw backdrop.
 fn composite_into_f32(
   base: &mut Rgba32FImage,
   top: &Rgba32FImage,
@@ -2297,13 +2330,21 @@ fn composite_into_f32(
     for ry in 0..rh {
       for rx in 0..rw {
         let s = top.get_pixel(otx + rx, oty + ry).0;
-        // Compute the effective source alpha first. When it is 0 and the mode does not clear
-        // based on the source, the output equals the backdrop — skip the pixel so `norm_f32`
-        // does NOT clamp / sanitize the (possibly HDR > 1 or NaN) destination for a true no-op
-        // overlay. Only the f32 path needs this; u8/u16 normalize losslessly.
+        // Read the destination first (raw, possibly HDR > 1 or NaN) so we can preserve it exactly
+        // for modes that leave the backdrop untouched, instead of clamping it via `norm_f32`. The
+        // blend itself runs in `[0,1]`; only the f32 path needs these guards (u8/u16 normalize
+        // losslessly). Destination is preserved when:
+        //   - the mode ignores the source entirely (`Dest`), or
+        //   - the source is fully transparent and the mode does not clear on a transparent source, or
+        //   - `DestOver` over a fully-opaque backdrop (the backdrop fully covers the source).
         let a_s = (norm_f32(s[3]) * opacity).clamp(0.0, 1.0);
-        if a_s == 0.0 && !clears_dest_when_source_transparent(mode) {
-          continue;
+        let d_raw = base.get_pixel(obx + rx, oby + ry).0;
+        let dst_a = d_raw[3]; // raw backdrop alpha BEFORE norm
+        let preserves_dest = mode == BlendMode::Dest
+          || (a_s == 0.0 && !clears_dest_when_source_transparent(mode))
+          || (mode == BlendMode::DestOver && dst_a >= 1.0);
+        if preserves_dest {
+          continue; // leave the original (possibly HDR / NaN) destination untouched
         }
         let cs = [
           norm_f32(s[0]),
@@ -2311,12 +2352,11 @@ fn composite_into_f32(
           norm_f32(s[2]),
           norm_f32(s[3]),
         ];
-        let d = base.get_pixel(obx + rx, oby + ry).0;
         let cb = [
-          norm_f32(d[0]),
-          norm_f32(d[1]),
-          norm_f32(d[2]),
-          norm_f32(d[3]),
+          norm_f32(d_raw[0]),
+          norm_f32(d_raw[1]),
+          norm_f32(d_raw[2]),
+          norm_f32(d_raw[3]),
         ];
         let out = blend_rgba_f32(cb, cs, mode, opacity);
         base.put_pixel(obx + rx, oby + ry, Rgba(out));
@@ -2499,7 +2539,7 @@ mod tests {
 
   use super::{
     BlendMode, Gravity, ImageTransformArgs, apply_composite, apply_contrast, apply_huerotate,
-    apply_opacity, apply_transforms, resolve_position,
+    apply_opacity, apply_transforms, for_each_placement, resolve_position,
   };
   use image::{ColorType, DynamicImage, ImageBuffer, RgbImage, RgbaImage};
 
@@ -3229,5 +3269,67 @@ mod tests {
         px[c]
       );
     }
+  }
+
+  #[test]
+  fn composite_dest_preserves_hdr_destination() {
+    // `Dest` ignores the source entirely: an HDR Rgba32F backdrop (channel > 1.0) must survive an
+    // opaque top untouched (not clamped to 1.0) and stay Rgba32F.
+    let mut base = DynamicImage::ImageRgba32F(
+      image::ImageBuffer::<image::Rgba<f32>, _>::from_raw(1, 1, vec![4.0, 2.0, 0.5, 1.0]).unwrap(),
+    );
+    let top = DynamicImage::ImageRgba32F(
+      image::ImageBuffer::<image::Rgba<f32>, _>::from_raw(1, 1, vec![1.0, 1.0, 1.0, 1.0]).unwrap(),
+    );
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Dest, 1.0, false);
+    assert_eq!(base.color(), ColorType::Rgba32F, "must stay Rgba32F");
+    let px = base.to_rgba32f().get_pixel(0, 0).0;
+    assert_eq!(
+      px[0], 4.0,
+      "Dest must keep the HDR backdrop (not clamp to 1.0)"
+    );
+    assert_eq!(px[1], 2.0);
+    assert_eq!(px[2], 0.5);
+    assert_eq!(px[3], 1.0);
+  }
+
+  #[test]
+  fn composite_dest_over_preserves_hdr_over_opaque_backdrop() {
+    // `DestOver` over a fully-opaque backdrop leaves the backdrop visible. The HDR Rgba32F base
+    // (channel > 1.0, alpha 1.0) must be preserved exactly, not clamped via the [0,1] blend.
+    let mut base = DynamicImage::ImageRgba32F(
+      image::ImageBuffer::<image::Rgba<f32>, _>::from_raw(1, 1, vec![4.0, 2.0, 0.5, 1.0]).unwrap(),
+    );
+    let top = DynamicImage::ImageRgba32F(
+      image::ImageBuffer::<image::Rgba<f32>, _>::from_raw(1, 1, vec![0.1, 0.2, 0.3, 1.0]).unwrap(),
+    );
+    apply_composite(&mut base, &top, 0, 0, BlendMode::DestOver, 1.0, false);
+    assert_eq!(base.color(), ColorType::Rgba32F, "must stay Rgba32F");
+    let px = base.to_rgba32f().get_pixel(0, 0).0;
+    assert_eq!(
+      px[0], 4.0,
+      "DestOver over an opaque HDR backdrop must keep it (not clamp to 1.0)"
+    );
+    assert_eq!(px[1], 2.0);
+    assert_eq!(px[2], 0.5);
+    assert_eq!(px[3], 1.0);
+  }
+
+  #[test]
+  fn tile_placement_is_phased_by_resolved_offset() {
+    // A 2x2 tile over a 4x4 base resolved at x=1, y=0 must phase the grid so a tile origin lands on
+    // x=1: origins step by the tile size from `x mod tw - tw`, giving x in {-1, 1, 3} (NOT {0, 2}).
+    let mut origins: Vec<(i64, i64)> = Vec::new();
+    for_each_placement(true, 4, 4, 2, 2, 1, 0, |ox, oy| origins.push((ox, oy)));
+
+    let mut xs: Vec<i64> = origins.iter().map(|&(ox, _)| ox).collect();
+    xs.sort_unstable();
+    xs.dedup();
+    assert_eq!(xs, vec![-1, 1, 3], "tile x origins must be phased by x=1");
+
+    let mut ys: Vec<i64> = origins.iter().map(|&(_, oy)| oy).collect();
+    ys.sort_unstable();
+    ys.dedup();
+    assert_eq!(ys, vec![-2, 0, 2], "tile y origins must be phased by y=0");
   }
 }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -1377,6 +1377,12 @@ impl Transformer {
   /// (where the W3C blend modes are defined), so HDR channel values outside `[0,1]` in the
   /// composited region are clamped; fully-transparent sources, `Dest`, and `DestOver` over an
   /// opaque backdrop are preserved exactly.
+  ///
+  /// Blending follows the W3C "Compositing and Blending Level 1" model (the same one used by CSS
+  /// `mix-blend-mode`, SVG, and Canvas). Results match sharp/libvips for opaque inputs and for
+  /// `Over` at any alpha; for a translucent source or backdrop combined with a separable blend mode
+  /// (Multiply, Screen, HardLight, etc.), per-pixel values differ from sharp, which uses
+  /// premultiplied-alpha math.
   pub fn composite(
     &mut self,
     on_top: Uint8Array,

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -1338,8 +1338,9 @@ impl Transformer {
   /// Source-over (`blend: Over`, no tiling, full opacity) composites at 8-bit, identical
   /// to `overlay`. Other blend modes / tiling / opacity < 1 run at the base image's native
   /// channel depth (8/16-bit, or 32-bit float), then the result is converted back to the
-  /// base's original color type — so an opaque base never gains an alpha channel, and
-  /// alpha-reducing modes (Clear/Out/DestOut/Xor) have no visible effect on an opaque base.
+  /// base's original color type — so an opaque base never gains an alpha channel. On an
+  /// opaque base, coverage-reducing modes (Clear/Out/DestOut/Xor) flatten the overlapped
+  /// region toward black, since the removed alpha can't be stored without an alpha channel.
   pub fn composite(
     &mut self,
     on_top: Uint8Array,
@@ -2965,5 +2966,57 @@ mod tests {
       ColorType::Rgb8,
       "opaque base must stay Rgb8 (no alpha channel added)"
     );
+  }
+
+  #[test]
+  fn composite_over_applies_per_overlay_opacity() {
+    // A faded overlay (opacity 0.5) Over an opaque base must blend half-and-half. With
+    // a_s = top_alpha * opacity = 0.5 and ab = 1, Over gives Fa = 1, Fb = 1 - a_s = 0.5,
+    // so ao = 0.5*1 + 1*0.5 = 1.0. Red fades to ~0.5 (128), the base blue keeps ~0.5
+    // (128), green stays 0, and the opaque base keeps full alpha + its Rgba8 color type.
+    let mut base =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![0, 0, 255, 255]).unwrap());
+    let top = DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![255, 0, 0, 255]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Over, 0.5, false);
+    assert_eq!(base.color(), ColorType::Rgba8);
+    let px = base.to_rgba8().get_pixel(0, 0).0;
+    assert!(
+      (127..=129).contains(&px[0]),
+      "R ~= 128 (half-faded red); got {}",
+      px[0]
+    );
+    assert_eq!(px[1], 0, "green stays 0");
+    assert!(
+      (127..=129).contains(&px[2]),
+      "B ~= 128 (half-kept base blue); got {}",
+      px[2]
+    );
+    assert_eq!(px[3], 255, "opaque base keeps full alpha");
+  }
+
+  #[test]
+  fn composite_multiply_runs_at_16bit_depth() {
+    // The 16-bit branch (`composite_into_u16`) must blend at full depth. Multiply of two
+    // mid-grays: 32768/65535 ~= 0.50000763, squared ~= 0.25000763, * 65535 ~= 16384.25,
+    // rounding to ~16384 — the result keeps 16-bit precision and the base stays Rgba16.
+    let mut base = DynamicImage::ImageRgba16(
+      image::ImageBuffer::<image::Rgba<u16>, _>::from_raw(1, 1, vec![32768, 32768, 32768, 65535])
+        .unwrap(),
+    );
+    let top = DynamicImage::ImageRgba16(
+      image::ImageBuffer::<image::Rgba<u16>, _>::from_raw(1, 1, vec![32768, 32768, 32768, 65535])
+        .unwrap(),
+    );
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Multiply, 1.0, false);
+    assert_eq!(base.color(), ColorType::Rgba16, "must stay 16-bit");
+    let px = base.to_rgba16().get_pixel(0, 0).0;
+    for c in 0..3 {
+      assert!(
+        (16380..=16388).contains(&px[c]),
+        "channel {c}: 16-bit Multiply ~= 16384; got {}",
+        px[c]
+      );
+    }
+    assert_eq!(px[3], 65535, "opaque alpha preserved at 16-bit");
   }
 }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -2288,6 +2288,21 @@ fn composite_into_u8(
       }
     }
   });
+  // sharp parity: for clearing Porter-Duff modes the overlay sits on a full transparent canvas,
+  // so the area the (non-tiled) overlay does NOT cover is blended against a transparent source —
+  // which clears it to [0,0,0,0]. (Tiling already covers the whole base, so there is no outside.)
+  if !tile && clears_dest_when_source_transparent(mode) {
+    let (obx, oby, _, _, rw, rh) = overlap_bounds(bw, bh, tw, th, x, y);
+    for py in 0..bh {
+      let inside_y = py >= oby && py < oby + rh;
+      for px in 0..bw {
+        if inside_y && px >= obx && px < obx + rw {
+          continue; // covered by the overlay -> already blended above
+        }
+        base.put_pixel(px, py, Rgba([0, 0, 0, 0]));
+      }
+    }
+  }
 }
 
 /// Composite `top` onto a 16-bit RGBA `base` in place. Channels normalize `/65535`, denormalize
@@ -2348,6 +2363,21 @@ fn composite_into_u16(
       }
     }
   });
+  // sharp parity: for clearing Porter-Duff modes the overlay sits on a full transparent canvas,
+  // so the area the (non-tiled) overlay does NOT cover is blended against a transparent source —
+  // which clears it to [0,0,0,0]. (Tiling already covers the whole base, so there is no outside.)
+  if !tile && clears_dest_when_source_transparent(mode) {
+    let (obx, oby, _, _, rw, rh) = overlap_bounds(bw, bh, tw, th, x, y);
+    for py in 0..bh {
+      let inside_y = py >= oby && py < oby + rh;
+      for px in 0..bw {
+        if inside_y && px >= obx && px < obx + rw {
+          continue; // covered by the overlay -> already blended above
+        }
+        base.put_pixel(px, py, Rgba([0u16, 0, 0, 0]));
+      }
+    }
+  }
 }
 
 /// Composite `top` onto a 32-bit float RGBA `base` in place. The W3C blend modes are defined in
@@ -2407,6 +2437,21 @@ fn composite_into_f32(
       }
     }
   });
+  // sharp parity: for clearing Porter-Duff modes the overlay sits on a full transparent canvas,
+  // so the area the (non-tiled) overlay does NOT cover is blended against a transparent source —
+  // which clears it to [0,0,0,0]. (Tiling already covers the whole base, so there is no outside.)
+  if !tile && clears_dest_when_source_transparent(mode) {
+    let (obx, oby, _, _, rw, rh) = overlap_bounds(bw, bh, tw, th, x, y);
+    for py in 0..bh {
+      let inside_y = py >= oby && py < oby + rh;
+      for px in 0..bw {
+        if inside_y && px >= obx && px < obx + rw {
+          continue; // covered by the overlay -> already blended above
+        }
+        base.put_pixel(px, py, Rgba([0.0f32, 0.0, 0.0, 0.0]));
+      }
+    }
+  }
 }
 
 /// Convert the composited RGBA `DynamicImage` back to the base's `original` color family, so an
@@ -3187,6 +3232,126 @@ mod tests {
         assert_eq!(
           out.get_pixel(x, y).0,
           [10, 20, 30, 255],
+          "tile must cover pixel ({x}, {y})"
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn composite_u8_clearing_mode_clears_outside_overlay() {
+    // sharp places a composite overlay on a full transparent canvas, so for the clearing
+    // Porter-Duff modes a sub-base overlay clears the area it does NOT cover to transparent
+    // [0,0,0,0]. The overlap pixel still blends normally; non-clearing modes preserve the outside.
+    let make_base = || {
+      RgbaImage::from_fn(2, 2, |x, y| {
+        let i = (y * 2 + x) as u8;
+        Rgba([10 + i * 30, 200 - i * 20, 50 + i * 10, 255])
+      })
+    };
+    let white = RgbaImage::from_pixel(1, 1, Rgba([255, 255, 255, 255]));
+    let orig00 = make_base().get_pixel(0, 0).0;
+
+    // DestIn keeps the dest where an opaque source is present; clears the uncovered outside.
+    let mut base = make_base();
+    composite_into_u8(&mut base, &white, 0, 0, BlendMode::DestIn, 1.0, false);
+    assert_eq!(
+      base.get_pixel(0, 0).0,
+      orig00,
+      "DestIn keeps the covered dest"
+    );
+    assert_eq!(base.get_pixel(1, 0).0, [0, 0, 0, 0]);
+    assert_eq!(base.get_pixel(0, 1).0, [0, 0, 0, 0]);
+    assert_eq!(base.get_pixel(1, 1).0, [0, 0, 0, 0]);
+
+    // Source replaces the covered pixel with the source; clears the outside.
+    let mut base = make_base();
+    composite_into_u8(&mut base, &white, 0, 0, BlendMode::Source, 1.0, false);
+    assert_eq!(base.get_pixel(0, 0).0, [255, 255, 255, 255]);
+    assert_eq!(base.get_pixel(1, 0).0, [0, 0, 0, 0]);
+    assert_eq!(base.get_pixel(0, 1).0, [0, 0, 0, 0]);
+    assert_eq!(base.get_pixel(1, 1).0, [0, 0, 0, 0]);
+
+    // Clear clears the overlap AND the outside.
+    let mut base = make_base();
+    composite_into_u8(&mut base, &white, 0, 0, BlendMode::Clear, 1.0, false);
+    for y in 0..2 {
+      for x in 0..2 {
+        assert_eq!(
+          base.get_pixel(x, y).0,
+          [0, 0, 0, 0],
+          "Clear clears ({x},{y})"
+        );
+      }
+    }
+
+    // Control: Over is NOT a clearing mode, so the outside must stay the ORIGINAL base.
+    let mut base = make_base();
+    composite_into_u8(&mut base, &white, 0, 0, BlendMode::Over, 1.0, false);
+    assert_eq!(
+      base.get_pixel(0, 0).0,
+      [255, 255, 255, 255],
+      "Over composites the covered pixel"
+    );
+    let orig = make_base();
+    assert_eq!(
+      base.get_pixel(1, 0).0,
+      orig.get_pixel(1, 0).0,
+      "Over preserves outside"
+    );
+    assert_eq!(
+      base.get_pixel(0, 1).0,
+      orig.get_pixel(0, 1).0,
+      "Over preserves outside"
+    );
+    assert_eq!(
+      base.get_pixel(1, 1).0,
+      orig.get_pixel(1, 1).0,
+      "Over preserves outside"
+    );
+  }
+
+  #[test]
+  fn composite_u16_clearing_mode_clears_outside_overlay() {
+    // u16 variant: a clearing mode (DestIn) clears the uncovered outside to u16 zeros while the
+    // covered pixel keeps the original 16-bit destination.
+    let make_base = || {
+      ImageBuffer::<Rgba<u16>, Vec<u16>>::from_fn(2, 2, |x, y| {
+        let i = (y * 2 + x) as u16;
+        Rgba([1000 + i * 5000, 60000 - i * 4000, 2000 + i * 1000, 65535])
+      })
+    };
+    let white =
+      ImageBuffer::<Rgba<u16>, Vec<u16>>::from_pixel(1, 1, Rgba([65535, 65535, 65535, 65535]));
+    let orig00 = make_base().get_pixel(0, 0).0;
+
+    let mut base = make_base();
+    composite_into_u16(&mut base, &white, 0, 0, BlendMode::DestIn, 1.0, false);
+    assert_eq!(
+      base.get_pixel(0, 0).0,
+      orig00,
+      "DestIn keeps the covered dest"
+    );
+    assert_eq!(base.get_pixel(1, 0).0, [0, 0, 0, 0]);
+    assert_eq!(base.get_pixel(0, 1).0, [0, 0, 0, 0]);
+    assert_eq!(base.get_pixel(1, 1).0, [0, 0, 0, 0]);
+  }
+
+  #[test]
+  fn composite_tiled_clearing_mode_covers_whole_base() {
+    // Tiling already covers the whole base, so the outside-clear must NOT run for tile: every
+    // pixel is painted by the (Source) tile, none cleared to transparent.
+    let mut base = RgbaImage::from_fn(2, 2, |x, y| {
+      let i = (y * 2 + x) as u8;
+      Rgba([10 + i * 30, 200 - i * 20, 50 + i * 10, 255])
+    });
+    let white = RgbaImage::from_pixel(1, 1, Rgba([255, 255, 255, 255]));
+    composite_into_u8(&mut base, &white, 0, 0, BlendMode::Source, 1.0, true);
+    for y in 0..2 {
+      for x in 0..2 {
+        assert_eq!(
+          base.get_pixel(x, y).0,
+          [255, 255, 255, 255],
           "tile must cover pixel ({x}, {y})"
         );
       }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -906,6 +906,9 @@ impl Task for EncodeTask {
       }
       // Collapse the RGBA working buffer back to the pre-composite color type once, after the whole
       // chain (flatten onto black first if that type had no alpha). Legacy overlay() is unaffected.
+      // Any legacy overlay() interleaved among composite() items also draws onto this same live RGBA
+      // buffer, so alpha from an earlier composite is visible to later overlay()/composite() items —
+      // matching sharp's flatten-at-encode model.
       if did_composite {
         finalize_composite(&mut img, pre_composite_color);
       }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -2261,6 +2261,16 @@ fn composite_into_u8(
           d[2] as f32 / 255.0,
           d[3] as f32 / 255.0,
         ];
+        let a_s = (cs[3] * opacity).clamp(0.0, 1.0);
+        // Mirror composite_into_f32's destination-preserving skip so a no-op composite
+        // (Dest, transparent-source no-op, DestOver over an opaque backdrop) keeps the
+        // destination's color stored under alpha 0 instead of canonicalizing it to black.
+        let preserves_dest = mode == BlendMode::Dest
+          || (a_s == 0.0 && !clears_dest_when_source_transparent(mode))
+          || (mode == BlendMode::DestOver && cb[3] >= 1.0);
+        if preserves_dest {
+          continue;
+        }
         let out = blend_rgba_f32(cb, cs, mode, opacity);
         base.put_pixel(
           obx + rx,
@@ -2311,6 +2321,16 @@ fn composite_into_u16(
           d[2] as f32 / 65535.0,
           d[3] as f32 / 65535.0,
         ];
+        let a_s = (cs[3] * opacity).clamp(0.0, 1.0);
+        // Mirror composite_into_f32's destination-preserving skip so a no-op composite
+        // (Dest, transparent-source no-op, DestOver over an opaque backdrop) keeps the
+        // destination's color stored under alpha 0 instead of canonicalizing it to black.
+        let preserves_dest = mode == BlendMode::Dest
+          || (a_s == 0.0 && !clears_dest_when_source_transparent(mode))
+          || (mode == BlendMode::DestOver && cb[3] >= 1.0);
+        if preserves_dest {
+          continue;
+        }
         let out = blend_rgba_f32(cb, cs, mode, opacity);
         base.put_pixel(
           obx + rx,
@@ -2586,10 +2606,10 @@ mod tests {
 
   use super::{
     BlendMode, Gravity, ImageTransformArgs, apply_composite, apply_contrast, apply_huerotate,
-    apply_opacity, apply_transforms, composite_step, finalize_composite, for_each_placement,
-    resolve_position,
+    apply_opacity, apply_transforms, composite_into_u8, composite_into_u16, composite_step,
+    finalize_composite, for_each_placement, resolve_position,
   };
-  use image::{ColorType, DynamicImage, ImageBuffer, RgbImage, RgbaImage};
+  use image::{ColorType, DynamicImage, ImageBuffer, RgbImage, Rgba, RgbaImage};
 
   #[test]
   fn huerotate_preserves_16bit_color_through_pipeline() {
@@ -3390,6 +3410,64 @@ mod tests {
     assert_eq!(px[1], 2.0);
     assert_eq!(px[2], 0.5);
     assert_eq!(px[3], 1.0);
+  }
+
+  #[test]
+  fn composite_u8_preserves_color_under_transparent_alpha() {
+    // A destination pixel can carry non-black color UNDER a fully-transparent alpha. A no-op
+    // composite (Dest, or Over with opacity 0) must keep that color exactly, instead of letting
+    // blend_rgba_f32 canonicalize it to [0,0,0,0] when the result alpha is 0. This guard brings the
+    // u8 integer path to parity with the f32 path's destination-preserving skip.
+    let top = RgbaImage::from_pixel(2, 2, Rgba([255, 255, 255, 255]));
+
+    // Dest ignores the overlay entirely: every covered pixel must be preserved.
+    let mut base = RgbaImage::from_pixel(2, 2, Rgba([200, 100, 50, 0]));
+    composite_into_u8(&mut base, &top, 0, 0, BlendMode::Dest, 1.0, false);
+    for px in base.pixels() {
+      assert_eq!(
+        px.0,
+        [200, 100, 50, 0],
+        "Dest must preserve color under alpha 0"
+      );
+    }
+
+    // Over with opacity 0 is a no-op (a_s == 0, Over does not clear): preserve the same way.
+    let mut base = RgbaImage::from_pixel(2, 2, Rgba([200, 100, 50, 0]));
+    composite_into_u8(&mut base, &top, 0, 0, BlendMode::Over, 0.0, false);
+    for px in base.pixels() {
+      assert_eq!(
+        px.0,
+        [200, 100, 50, 0],
+        "Over with opacity 0 must preserve color under alpha 0"
+      );
+    }
+
+    // Sanity: a real Over (opaque top, opacity 1) over an opaque base MUST still change — the guard
+    // must not over-skip normal composites.
+    let mut base = RgbaImage::from_pixel(2, 2, Rgba([10, 20, 30, 255]));
+    composite_into_u8(&mut base, &top, 0, 0, BlendMode::Over, 1.0, false);
+    for px in base.pixels() {
+      assert_eq!(
+        px.0,
+        [255, 255, 255, 255],
+        "an opaque Over must still paint white (guard must not over-skip)"
+      );
+    }
+  }
+
+  #[test]
+  fn composite_u16_preserves_color_under_transparent_alpha() {
+    // 16-bit counterpart: Dest must keep the 16-bit color stored under alpha 0 exactly.
+    let top = ImageBuffer::<Rgba<u16>, _>::from_pixel(2, 2, Rgba([65535, 65535, 65535, 65535]));
+    let mut base = ImageBuffer::<Rgba<u16>, _>::from_pixel(2, 2, Rgba([40000, 20000, 10000, 0]));
+    composite_into_u16(&mut base, &top, 0, 0, BlendMode::Dest, 1.0, false);
+    for px in base.pixels() {
+      assert_eq!(
+        px.0,
+        [40000, 20000, 10000, 0],
+        "Dest must preserve 16-bit color under alpha 0"
+      );
+    }
   }
 
   #[test]

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -856,6 +856,10 @@ impl Task for EncodeTask {
     } else {
       let mut img = meta.image.clone();
       apply_transforms(&mut img, &self.image_transform_args, meta.orientation, true)?;
+      // Defer the composite flatten/restore to the end of the chain so intermediate alpha (e.g. a
+      // `DestOut` hole) survives for later items (#138). Capture the pre-composite color type.
+      let pre_composite_color = img.color();
+      let mut did_composite = false;
       for item in std::mem::take(&mut self.image_transform_args.overlay).into_iter() {
         let top = ThreadsafeDynamicImage::new(item.buffer.clone());
         let top_image_meta = top.get(true)?;
@@ -885,8 +889,11 @@ impl Task for EncodeTask {
           overlay(&mut img, &top_image_meta.image, x, y);
         } else {
           // composite(): always depth-aware at the base's native depth (8/16-bit or f32), so a
-          // default `Over` on an HDR base is not clamped to 8-bit and no-op guards apply.
-          apply_composite(
+          // default `Over` on an HDR base is not clamped to 8-bit and no-op guards apply. Keep the
+          // RGBA working buffer across the chain so intermediate alpha (e.g. a `DestOut` hole)
+          // survives for later items; flatten/restore happens once after the loop (#138).
+          did_composite = true;
+          composite_step(
             &mut img,
             &top_image_meta.image,
             x,
@@ -896,6 +903,11 @@ impl Task for EncodeTask {
             item.tile,
           );
         }
+      }
+      // Collapse the RGBA working buffer back to the pre-composite color type once, after the whole
+      // chain (flatten onto black first if that type had no alpha). Legacy overlay() is unaffected.
+      if did_composite {
+        finalize_composite(&mut img, pre_composite_color);
       }
       owned = img;
       &owned
@@ -2425,8 +2437,59 @@ fn flatten_on_black_f32(img: &mut Rgba32FImage) {
   }
 }
 
-/// Composite `top` onto `base` at `(x, y)` (or tiled) with `mode`/`opacity`. Works at the base's
-/// native channel depth (8/16-bit or 32-bit float), then restores the base's ORIGINAL color type.
+/// One composite step: composite `top` onto `base` at the base's native depth and leave `base`
+/// as the RGBA working image (Rgba8/Rgba16/Rgba32F). Does NOT flatten or restore the color type,
+/// so chained composites keep intermediate alpha. Call `finalize_composite` once after the chain.
+fn composite_step(
+  base: &mut DynamicImage,
+  top: &DynamicImage,
+  x: i64,
+  y: i64,
+  mode: BlendMode,
+  opacity: f32,
+  tile: bool,
+) {
+  // Choose working depth from the base. 16-bit -> Rgba16; 32-bit float -> Rgba32F; else Rgba8.
+  match base.color() {
+    ColorType::Rgba16 | ColorType::Rgb16 | ColorType::La16 | ColorType::L16 => {
+      let mut work = base.to_rgba16();
+      composite_into_u16(&mut work, &top.to_rgba16(), x, y, mode, opacity, tile);
+      *base = DynamicImage::ImageRgba16(work);
+    }
+    ColorType::Rgb32F | ColorType::Rgba32F => {
+      let mut work = base.to_rgba32f();
+      composite_into_f32(&mut work, &top.to_rgba32f(), x, y, mode, opacity, tile);
+      *base = DynamicImage::ImageRgba32F(work);
+    }
+    _ => {
+      let mut work = base.to_rgba8();
+      composite_into_u8(&mut work, &top.to_rgba8(), x, y, mode, opacity, tile);
+      *base = DynamicImage::ImageRgba8(work);
+    }
+  }
+}
+
+/// Collapse the RGBA working image back to `original` after the composite chain. If `original`
+/// has no alpha channel, flatten the accumulated alpha onto black first (so a coverage-reducing
+/// final result is visible), then restore the original color type.
+fn finalize_composite(base: &mut DynamicImage, original: ColorType) {
+  if !original.has_alpha() {
+    match base {
+      DynamicImage::ImageRgba16(work) => flatten_on_black_u16(work),
+      DynamicImage::ImageRgba32F(work) => flatten_on_black_f32(work),
+      DynamicImage::ImageRgba8(work) => flatten_on_black_u8(work),
+      _ => {}
+    }
+  }
+  let working = std::mem::replace(base, DynamicImage::ImageRgba8(ImageBuffer::new(0, 0)));
+  *base = restore_color_type(working, original);
+}
+
+/// Composite a single overlay end-to-end (step + finalize). Used by the unit tests and any
+/// single-shot caller; the encode pipeline uses `composite_step` across the chain + one
+/// `finalize_composite` at the end (see `compute`). Works at the base's native channel depth
+/// (8/16-bit or 32-bit float), then restores the base's ORIGINAL color type.
+#[cfg_attr(not(test), allow(dead_code))]
 fn apply_composite(
   base: &mut DynamicImage,
   top: &DynamicImage,
@@ -2437,33 +2500,8 @@ fn apply_composite(
   tile: bool,
 ) {
   let original = base.color();
-  // Choose working depth from the base. 16-bit -> Rgba16; 32-bit float -> Rgba32F; else Rgba8.
-  match original {
-    ColorType::Rgba16 | ColorType::Rgb16 | ColorType::La16 | ColorType::L16 => {
-      let mut work = base.to_rgba16();
-      composite_into_u16(&mut work, &top.to_rgba16(), x, y, mode, opacity, tile);
-      if !original.has_alpha() {
-        flatten_on_black_u16(&mut work);
-      }
-      *base = restore_color_type(DynamicImage::ImageRgba16(work), original);
-    }
-    ColorType::Rgb32F | ColorType::Rgba32F => {
-      let mut work = base.to_rgba32f();
-      composite_into_f32(&mut work, &top.to_rgba32f(), x, y, mode, opacity, tile);
-      if !original.has_alpha() {
-        flatten_on_black_f32(&mut work);
-      }
-      *base = restore_color_type(DynamicImage::ImageRgba32F(work), original);
-    }
-    _ => {
-      let mut work = base.to_rgba8();
-      composite_into_u8(&mut work, &top.to_rgba8(), x, y, mode, opacity, tile);
-      if !original.has_alpha() {
-        flatten_on_black_u8(&mut work);
-      }
-      *base = restore_color_type(DynamicImage::ImageRgba8(work), original);
-    }
-  }
+  composite_step(base, top, x, y, mode, opacity, tile);
+  finalize_composite(base, original);
 }
 
 #[inline]
@@ -2545,7 +2583,8 @@ mod tests {
 
   use super::{
     BlendMode, Gravity, ImageTransformArgs, apply_composite, apply_contrast, apply_huerotate,
-    apply_opacity, apply_transforms, for_each_placement, resolve_position,
+    apply_opacity, apply_transforms, composite_step, finalize_composite, for_each_placement,
+    resolve_position,
   };
   use image::{ColorType, DynamicImage, ImageBuffer, RgbImage, RgbaImage};
 
@@ -3273,6 +3312,35 @@ mod tests {
         (98..=102).contains(&px[c]),
         "channel {c}: ~100 after half-flatten; got {}",
         px[c]
+      );
+    }
+  }
+
+  #[test]
+  fn composite_chain_preserves_intermediate_alpha_on_opaque_base() {
+    // Two chained composites on a no-alpha Rgb8 base, mirroring the compute() flow (step xN +
+    // finalize once). `DestOut` with an opaque top punches a full hole (ao -> 0); the later
+    // `DestOver` must fill that hole with green. Deferring flatten/restore to `finalize_composite`
+    // keeps the intermediate alpha alive between steps so the green shows through instead of being
+    // flattened to black per-item (#138).
+    let fill = |px: [u8; 4]| -> Vec<u8> { px.iter().copied().cycle().take(2 * 2 * 4).collect() };
+    let mut base = DynamicImage::ImageRgb8(RgbImage::from_raw(2, 2, vec![255; 2 * 2 * 3]).unwrap());
+    let top_a =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(2, 2, fill([10, 20, 30, 255])).unwrap());
+    let top_b =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(2, 2, fill([0, 255, 0, 255])).unwrap());
+    let original = base.color();
+    composite_step(&mut base, &top_a, 0, 0, BlendMode::DestOut, 1.0, false);
+    composite_step(&mut base, &top_b, 0, 0, BlendMode::DestOver, 1.0, false);
+    finalize_composite(&mut base, original);
+    assert_eq!(base.color(), ColorType::Rgb8, "opaque base stays Rgb8");
+    let img = base.to_rgb8();
+    for px in img.pixels() {
+      assert_eq!(
+        px.0,
+        [0, 255, 0],
+        "DestOver must fill the DestOut hole with green, not flattened black; got {:?}",
+        px.0
       );
     }
   }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -859,8 +859,13 @@ impl Task for EncodeTask {
       // Defer the composite flatten/restore to the end of the chain so intermediate alpha (e.g. a
       // `DestOut` hole) survives for later items (#138). Capture the pre-composite color type.
       let pre_composite_color = img.color();
-      let mut did_composite = false;
-      for item in std::mem::take(&mut self.image_transform_args.overlay).into_iter() {
+      let items = std::mem::take(&mut self.image_transform_args.overlay);
+      // If the chain contains any composite(), run the WHOLE chain through the depth-aware path so a
+      // chained legacy overlay() also blends at the working depth (16/32-bit) instead of being crushed
+      // to 8-bit by image::imageops::overlay. A pure overlay()-only chain (no composite present) keeps
+      // the byte-identical legacy fast path.
+      let has_composite = items.iter().any(|item| !item.simple_overlay);
+      for item in items.into_iter() {
         let top = ThreadsafeDynamicImage::new(item.buffer.clone());
         let top_image_meta = top.get(true)?;
         // Fix D: composite() rejects an overlay larger than the base in either dimension (sharp
@@ -884,15 +889,13 @@ impl Task for EncodeTask {
           top_image_meta.image.width(),
           top_image_meta.image.height(),
         );
-        if item.simple_overlay {
+        if item.simple_overlay && !has_composite {
           // Legacy overlay(): byte-identical 8-bit source-over (clips oversized overlays).
           overlay(&mut img, &top_image_meta.image, x, y);
         } else {
-          // composite(): always depth-aware at the base's native depth (8/16-bit or f32), so a
-          // default `Over` on an HDR base is not clamped to 8-bit and no-op guards apply. Keep the
-          // RGBA working buffer across the chain so intermediate alpha (e.g. a `DestOut` hole)
-          // survives for later items; flatten/restore happens once after the loop (#138).
-          did_composite = true;
+          // Depth-aware at the base's native depth (8/16-bit or f32). An interleaved legacy overlay()
+          // (Over, opacity 1, no tile) is promoted here too so 16/32-bit precision is preserved across
+          // the chain. The RGBA working buffer is kept; flatten/restore happens once after the loop (#138).
           composite_step(
             &mut img,
             &top_image_meta.image,
@@ -909,7 +912,7 @@ impl Task for EncodeTask {
       // Any legacy overlay() interleaved among composite() items also draws onto this same live RGBA
       // buffer, so alpha from an earlier composite is visible to later overlay()/composite() items —
       // matching sharp's flatten-at-encode model.
-      if did_composite {
+      if has_composite {
         finalize_composite(&mut img, pre_composite_color);
       }
       owned = img;
@@ -3468,6 +3471,42 @@ mod tests {
         "Dest must preserve 16-bit color under alpha 0"
       );
     }
+  }
+
+  #[test]
+  fn mixed_chain_overlay_promoted_to_depth_aware_preserves_16bit() {
+    // 258 is NOT representable in 8-bit: round(258/65535*255) = 1 -> back to u16 = 257. So an 8-bit
+    // overlay crushes it, a depth-aware composite_step(Over) keeps it. This is why compute() routes a
+    // chained overlay() through composite_step when the chain contains a composite().
+    let top16 = DynamicImage::ImageRgba16(ImageBuffer::<Rgba<u16>, _>::from_pixel(
+      2,
+      2,
+      Rgba([258, 258, 258, 65535]),
+    ));
+    // depth-aware path (what mixed-chain overlay now uses):
+    let mut a = DynamicImage::ImageRgba16(ImageBuffer::<Rgba<u16>, _>::from_pixel(
+      2,
+      2,
+      Rgba([0, 0, 0, 65535]),
+    ));
+    composite_step(&mut a, &top16, 0, 0, BlendMode::Over, 1.0, false);
+    assert_eq!(
+      a.to_rgba16().get_pixel(0, 0).0[0],
+      258,
+      "depth-aware Over preserves 16-bit precision"
+    );
+    // legacy 8-bit overlay path (what a chained overlay() used to do):
+    let mut b = DynamicImage::ImageRgba16(ImageBuffer::<Rgba<u16>, _>::from_pixel(
+      2,
+      2,
+      Rgba([0, 0, 0, 65535]),
+    ));
+    image::imageops::overlay(&mut b, &top16, 0, 0);
+    assert_eq!(
+      b.to_rgba16().get_pixel(0, 0).0[0],
+      257,
+      "legacy 8-bit overlay crushes 16-bit precision"
+    );
   }
 
   #[test]

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -142,11 +142,12 @@ pub enum BlendMode {
 }
 
 #[napi]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 /// Where to anchor the overlay relative to the base image when no explicit
 /// `left`/`top` is given.
 pub enum Gravity {
   /// Center of the base image.
+  #[default]
   Center,
   /// Top edge, horizontally centered.
   North,
@@ -583,11 +584,14 @@ pub struct ResizeOptions {
 #[napi(object)]
 #[derive(Clone, Default)]
 pub struct CompositeOptions {
-  /// Pixel offset from the top edge. Takes precedence over `gravity` when set.
+  /// Pixel offset from the top edge. Provide both `top` and `left` together;
+  /// supplying only one is an error. When set, takes precedence over `gravity`.
   pub top: Option<i64>,
-  /// Pixel offset from the left edge. Takes precedence over `gravity` when set.
+  /// Pixel offset from the left edge. Provide both `left` and `top` together;
+  /// supplying only one is an error. When set, takes precedence over `gravity`.
   pub left: Option<i64>,
-  /// Anchor position; used only when neither `left` nor `top` is provided.
+  /// Anchor position. Defaults to `Center`; used only when neither `left` nor
+  /// `top` is set.
   pub gravity: Option<Gravity>,
   /// Blend / compositing operator. Defaults to `Over` (source-over).
   pub blend: Option<BlendMode>,
@@ -606,7 +610,8 @@ struct CompositeItem {
   buffer: Arc<Uint8Array>,
   left: i64,
   top: i64,
-  gravity: Option<Gravity>,
+  has_offset: bool, // both left & top were given (or legacy overlay())
+  gravity: Gravity, // used only when !has_offset; defaults to Center
   blend: BlendMode,
   tile: bool,
   opacity: f32, // 1.0 == no-op
@@ -853,7 +858,10 @@ impl Task for EncodeTask {
         let top = ThreadsafeDynamicImage::new(item.buffer.clone());
         let top_image_meta = top.get(true)?;
         let (x, y) = resolve_position(
-          &item,
+          item.has_offset,
+          item.left,
+          item.top,
+          item.gravity,
           img.width(),
           img.height(),
           top_image_meta.image.width(),
@@ -1323,7 +1331,8 @@ impl Transformer {
       buffer: Arc::new(on_top),
       left: x,
       top: y,
-      gravity: None,
+      has_offset: true,         // legacy overlay() is always an explicit offset
+      gravity: Gravity::Center, // unused when has_offset
       blend: BlendMode::Over,
       tile: false,
       opacity: 1.0,
@@ -1334,6 +1343,10 @@ impl Transformer {
   #[napi]
   /// Composite `on_top` onto this image with a sharp-style blend mode, gravity-based
   /// positioning, tiling, and per-overlay opacity. See `CompositeOptions`.
+  ///
+  /// Placement (sharp parity): when neither `left` nor `top` is given the overlay is
+  /// anchored by `gravity`, which defaults to the CENTRE of the base image. `left` and
+  /// `top` must be provided together — supplying only one is an error.
   ///
   /// Source-over (`blend: Over`, no tiling, full opacity) composites at 8-bit, identical
   /// to `overlay`. Other blend modes / tiling / opacity < 1 run at the base image's native
@@ -1347,14 +1360,31 @@ impl Transformer {
     options: Option<CompositeOptions>,
   ) -> Result<&Self> {
     let o = options.unwrap_or_default();
+    let has_offset = match (o.left, o.top) {
+      (Some(_), Some(_)) => true,
+      (None, None) => false,
+      _ => {
+        return Err(Error::new(
+          Status::InvalidArg,
+          "composite: `left` and `top` must be provided together".to_owned(),
+        ));
+      }
+    };
+    let opacity = o.opacity.unwrap_or(1.0) as f32;
+    let opacity = if opacity.is_finite() {
+      opacity.clamp(0.0, 1.0)
+    } else {
+      1.0
+    };
     self.image_transform_args.overlay.push(CompositeItem {
       buffer: Arc::new(on_top),
       left: o.left.unwrap_or(0),
       top: o.top.unwrap_or(0),
-      gravity: o.gravity,
+      has_offset,
+      gravity: o.gravity.unwrap_or_default(),
       blend: o.blend.unwrap_or_default(),
       tile: o.tile.unwrap_or(false),
-      opacity: (o.opacity.unwrap_or(1.0) as f32).clamp(0.0, 1.0),
+      opacity,
     });
     Ok(self)
   }
@@ -1904,20 +1934,29 @@ fn apply_opacity(image: &mut DynamicImage, factor: f32) {
   }
 }
 
-/// Resolve the top-left placement of an overlay. Explicit `left`/`top` take precedence over
-/// `gravity` (sharp semantics): gravity is honored only when it is set AND both offsets are 0.
-/// Computed in i64; negative results are valid (the overlay is clipped by the compositor).
-fn resolve_position(item: &CompositeItem, bw: u32, bh: u32, tw: u32, th: u32) -> (i64, i64) {
-  if item.left != 0 || item.top != 0 || item.gravity.is_none() {
-    // explicit offset (or default 0,0 when neither offset nor gravity given)
-    return (item.left, item.top);
+/// Resolve the top-left placement of an overlay (sharp semantics). When an explicit offset was
+/// given (`has_offset`), `left`/`top` are used verbatim; otherwise the overlay is anchored by
+/// `gravity` (default Center). Computed in i64; negative results are valid (the overlay is
+/// clipped by the compositor).
+fn resolve_position(
+  has_offset: bool,
+  left: i64,
+  top: i64,
+  gravity: Gravity,
+  bw: u32,
+  bh: u32,
+  tw: u32,
+  th: u32,
+) -> (i64, i64) {
+  if has_offset {
+    return (left, top);
   }
   let (bw, bh, tw, th) = (bw as i64, bh as i64, tw as i64, th as i64);
   let cx = (bw - tw) / 2;
   let cy = (bh - th) / 2;
   let right = bw - tw;
   let bottom = bh - th;
-  match item.gravity.unwrap() {
+  match gravity {
     Gravity::NorthWest => (0, 0),
     Gravity::North => (cx, 0),
     Gravity::NorthEast => (right, 0),
@@ -2049,6 +2088,22 @@ fn norm_f32(v: f32) -> f32 {
   if v.is_nan() { 0.0 } else { v.clamp(0.0, 1.0) }
 }
 
+/// True for modes whose output, when the source is fully transparent (`a_s == 0`), is NOT the
+/// untouched backdrop (they clear / replace the overlapped region). For all other modes `a_s == 0`
+/// is a destination-preserving no-op, so the pixel can be skipped to avoid clamping HDR / NaN
+/// destinations in the f32 path.
+fn clears_dest_when_source_transparent(mode: BlendMode) -> bool {
+  matches!(
+    mode,
+    BlendMode::Clear
+      | BlendMode::Source
+      | BlendMode::In
+      | BlendMode::Out
+      | BlendMode::DestIn
+      | BlendMode::DestAtop
+  )
+}
+
 /// Overlap rectangle of `top` placed at `(x, y)` over a `bw x bh` base, clamped exactly like the
 /// `image` crate's `overlay_bounds_ext` (handles negative offsets and tops larger than the base).
 /// Returns `(origin_bottom_x, origin_bottom_y, origin_top_x, origin_top_y, x_range, y_range)`.
@@ -2087,9 +2142,11 @@ fn overlap_bounds(
   )
 }
 
-/// Placement offsets for an overlay. A single `(x, y)` normally; for tiling, top-left origins
-/// stepping by the overlay size across the whole base starting at `(0, 0)` (ignoring `x/y`).
-fn placement_offsets(
+/// Invoke `f(ox, oy)` for each placement: once at `(x, y)` normally; for tiling, at every
+/// top-left origin stepping by the overlay size across the whole base from `(0,0)` (ignoring x/y).
+/// Streams the origins instead of materializing a `Vec` — a 1x1 tile over a large base would
+/// otherwise allocate one tuple per pixel.
+fn for_each_placement(
   tile: bool,
   bw: u32,
   bh: u32,
@@ -2097,25 +2154,25 @@ fn placement_offsets(
   th: u32,
   x: i64,
   y: i64,
-) -> Vec<(i64, i64)> {
+  mut f: impl FnMut(i64, i64),
+) {
   if !tile {
-    return vec![(x, y)];
+    f(x, y);
+    return;
   }
-  let mut offsets = Vec::new();
   // Caller guards `tw > 0 && th > 0`; keep a defensive check so the loop always terminates.
   if tw == 0 || th == 0 {
-    return offsets;
+    return;
   }
   let mut oy = 0u32;
   while oy < bh {
     let mut ox = 0u32;
     while ox < bw {
-      offsets.push((ox as i64, oy as i64));
+      f(ox as i64, oy as i64);
       ox += tw;
     }
     oy += th;
   }
-  offsets
 }
 
 /// Composite `top` onto an 8-bit RGBA `base` in place. Channels normalize `/255`, denormalize
@@ -2134,7 +2191,7 @@ fn composite_into_u8(
   if tw == 0 || th == 0 {
     return;
   }
-  for (ox, oy) in placement_offsets(tile, bw, bh, tw, th, x, y) {
+  for_each_placement(tile, bw, bh, tw, th, x, y, |ox, oy| {
     let (obx, oby, otx, oty, rw, rh) = overlap_bounds(bw, bh, tw, th, ox, oy);
     for ry in 0..rh {
       for rx in 0..rw {
@@ -2165,7 +2222,7 @@ fn composite_into_u8(
         );
       }
     }
-  }
+  });
 }
 
 /// Composite `top` onto a 16-bit RGBA `base` in place. Channels normalize `/65535`, denormalize
@@ -2184,7 +2241,7 @@ fn composite_into_u16(
   if tw == 0 || th == 0 {
     return;
   }
-  for (ox, oy) in placement_offsets(tile, bw, bh, tw, th, x, y) {
+  for_each_placement(tile, bw, bh, tw, th, x, y, |ox, oy| {
     let (obx, oby, otx, oty, rw, rh) = overlap_bounds(bw, bh, tw, th, ox, oy);
     for ry in 0..rh {
       for rx in 0..rw {
@@ -2215,7 +2272,7 @@ fn composite_into_u16(
         );
       }
     }
-  }
+  });
 }
 
 /// Composite `top` onto a 32-bit float RGBA `base` in place. Channels are clamped to `[0,1]` for
@@ -2235,11 +2292,19 @@ fn composite_into_f32(
   if tw == 0 || th == 0 {
     return;
   }
-  for (ox, oy) in placement_offsets(tile, bw, bh, tw, th, x, y) {
+  for_each_placement(tile, bw, bh, tw, th, x, y, |ox, oy| {
     let (obx, oby, otx, oty, rw, rh) = overlap_bounds(bw, bh, tw, th, ox, oy);
     for ry in 0..rh {
       for rx in 0..rw {
         let s = top.get_pixel(otx + rx, oty + ry).0;
+        // Compute the effective source alpha first. When it is 0 and the mode does not clear
+        // based on the source, the output equals the backdrop — skip the pixel so `norm_f32`
+        // does NOT clamp / sanitize the (possibly HDR > 1 or NaN) destination for a true no-op
+        // overlay. Only the f32 path needs this; u8/u16 normalize losslessly.
+        let a_s = (norm_f32(s[3]) * opacity).clamp(0.0, 1.0);
+        if a_s == 0.0 && !clears_dest_when_source_transparent(mode) {
+          continue;
+        }
         let cs = [
           norm_f32(s[0]),
           norm_f32(s[1]),
@@ -2257,7 +2322,7 @@ fn composite_into_f32(
         base.put_pixel(obx + rx, oby + ry, Rgba(out));
       }
     }
-  }
+  });
 }
 
 /// Convert the composited RGBA `DynamicImage` back to the base's `original` color family, so an
@@ -2279,6 +2344,41 @@ fn restore_color_type(img: DynamicImage, original: ColorType) -> DynamicImage {
   }
 }
 
+/// Flatten an RGBA8 working buffer onto black: premultiply RGB by the result alpha, then force the
+/// alpha opaque. Used before dropping the alpha channel for an opaque base so a coverage-reducing
+/// result (e.g. `DestOut`) is actually visible instead of keeping the untouched straight RGB.
+fn flatten_on_black_u8(img: &mut RgbaImage) {
+  for p in img.pixels_mut() {
+    let a = p.0[3] as f32 / 255.0;
+    for c in 0..3 {
+      p.0[c] = (p.0[c] as f32 * a).round().clamp(0.0, 255.0) as u8;
+    }
+    p.0[3] = 255;
+  }
+}
+
+/// 16-bit counterpart of `flatten_on_black_u8`.
+fn flatten_on_black_u16(img: &mut ImageBuffer<Rgba<u16>, Vec<u16>>) {
+  for p in img.pixels_mut() {
+    let a = p.0[3] as f32 / 65535.0;
+    for c in 0..3 {
+      p.0[c] = (p.0[c] as f32 * a).round().clamp(0.0, 65535.0) as u16;
+    }
+    p.0[3] = 65535;
+  }
+}
+
+/// 32-bit float counterpart of `flatten_on_black_u8` (alpha already normalized to `[0,1]`).
+fn flatten_on_black_f32(img: &mut Rgba32FImage) {
+  for p in img.pixels_mut() {
+    let a = p.0[3];
+    for c in 0..3 {
+      p.0[c] *= a;
+    }
+    p.0[3] = 1.0;
+  }
+}
+
 /// Composite `top` onto `base` at `(x, y)` (or tiled) with `mode`/`opacity`. Works at the base's
 /// native channel depth (8/16-bit or 32-bit float), then restores the base's ORIGINAL color type.
 fn apply_composite(
@@ -2296,16 +2396,25 @@ fn apply_composite(
     ColorType::Rgba16 | ColorType::Rgb16 | ColorType::La16 | ColorType::L16 => {
       let mut work = base.to_rgba16();
       composite_into_u16(&mut work, &top.to_rgba16(), x, y, mode, opacity, tile);
+      if !original.has_alpha() {
+        flatten_on_black_u16(&mut work);
+      }
       *base = restore_color_type(DynamicImage::ImageRgba16(work), original);
     }
     ColorType::Rgb32F | ColorType::Rgba32F => {
       let mut work = base.to_rgba32f();
       composite_into_f32(&mut work, &top.to_rgba32f(), x, y, mode, opacity, tile);
+      if !original.has_alpha() {
+        flatten_on_black_f32(&mut work);
+      }
       *base = restore_color_type(DynamicImage::ImageRgba32F(work), original);
     }
     _ => {
       let mut work = base.to_rgba8();
       composite_into_u8(&mut work, &top.to_rgba8(), x, y, mode, opacity, tile);
+      if !original.has_alpha() {
+        flatten_on_black_u8(&mut work);
+      }
       *base = restore_color_type(DynamicImage::ImageRgba8(work), original);
     }
   }
@@ -2389,8 +2498,8 @@ mod tests {
   }
 
   use super::{
-    BlendMode, ImageTransformArgs, apply_composite, apply_contrast, apply_huerotate, apply_opacity,
-    apply_transforms,
+    BlendMode, Gravity, ImageTransformArgs, apply_composite, apply_contrast, apply_huerotate,
+    apply_opacity, apply_transforms, resolve_position,
   };
   use image::{ColorType, DynamicImage, ImageBuffer, RgbImage, RgbaImage};
 
@@ -3018,5 +3127,107 @@ mod tests {
       );
     }
     assert_eq!(px[3], 65535, "opaque alpha preserved at 16-bit");
+  }
+
+  #[test]
+  fn resolve_position_defaults_to_center() {
+    // No explicit offset + default Center gravity: a 2x2 top on a 4x4 base lands at (1, 1).
+    assert_eq!(
+      resolve_position(false, 0, 0, Gravity::Center, 4, 4, 2, 2),
+      (1, 1)
+    );
+  }
+
+  #[test]
+  fn resolve_position_southeast_gravity() {
+    // SouthEast anchors the 2x2 top at the bottom-right corner of a 4x4 base: (2, 2).
+    assert_eq!(
+      resolve_position(false, 0, 0, Gravity::SouthEast, 4, 4, 2, 2),
+      (2, 2)
+    );
+  }
+
+  #[test]
+  fn resolve_position_offset_overrides_gravity() {
+    // has_offset = true: the explicit (left, top) wins, gravity is ignored (negatives allowed).
+    assert_eq!(
+      resolve_position(true, 3, -2, Gravity::SouthEast, 4, 4, 2, 2),
+      (3, -2)
+    );
+  }
+
+  #[test]
+  fn composite_tile_streams_1x1_over_large_base() {
+    // A 1x1 opaque top tiled over an 8x8 base must paint every one of the 64 pixels. Proves the
+    // streaming `for_each_placement` loop is correct AND bounded (no per-pixel Vec allocation).
+    let mut base =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(8, 8, vec![1, 2, 3, 255].repeat(64)).unwrap());
+    let top = DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![7, 8, 9, 255]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Over, 1.0, true);
+    let out = base.to_rgba8();
+    for y in 0..8 {
+      for x in 0..8 {
+        assert_eq!(
+          out.get_pixel(x, y).0,
+          [7, 8, 9, 255],
+          "tile must cover pixel ({x}, {y})"
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn composite_f32_transparent_overlay_is_identity() {
+    // A fully transparent top over an HDR Rgba32F base (channel > 1.0) must leave the destination
+    // byte-for-byte untouched — the f32 no-op short-circuit must NOT clamp the highlight to 1.0.
+    let mut base = DynamicImage::ImageRgba32F(
+      image::ImageBuffer::<image::Rgba<f32>, _>::from_raw(1, 1, vec![4.0, 2.0, 0.5, 1.0]).unwrap(),
+    );
+    let top = DynamicImage::ImageRgba32F(
+      image::ImageBuffer::<image::Rgba<f32>, _>::from_raw(1, 1, vec![0.0, 0.0, 0.0, 0.0]).unwrap(),
+    );
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Over, 1.0, false);
+    assert_eq!(base.color(), ColorType::Rgba32F, "must stay Rgba32F");
+    let px = base.to_rgba32f().get_pixel(0, 0).0;
+    assert_eq!(
+      px[0], 4.0,
+      "HDR highlight must survive a no-op overlay (not clamped to 1.0)"
+    );
+    assert_eq!(px[1], 2.0);
+    assert_eq!(px[2], 0.5);
+    assert_eq!(px[3], 1.0);
+  }
+
+  #[test]
+  fn composite_dest_out_flattens_opaque_rgb_to_black() {
+    // DestOut with an opaque top fully clears coverage (ao -> 0). On an Rgb8 (no-alpha) base the
+    // overlapped region must flatten to black rather than keep the original RGB, and stay Rgb8.
+    let mut base = DynamicImage::ImageRgb8(RgbImage::from_raw(1, 1, vec![200, 200, 200]).unwrap());
+    let top = DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![123, 45, 67, 255]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::DestOut, 1.0, false);
+    assert_eq!(base.color(), ColorType::Rgb8, "opaque base stays Rgb8");
+    assert_eq!(
+      base.to_rgb8().get_pixel(0, 0).0,
+      [0, 0, 0],
+      "fully cleared coverage must flatten to black"
+    );
+  }
+
+  #[test]
+  fn composite_dest_out_half_flattens_opaque_rgb() {
+    // A 50%-opaque DestOut top halves coverage (ao ~= 0.5). Flatten-on-black scales the kept RGB
+    // by that alpha: 200 * 0.5 ~= 100. Stays Rgb8.
+    let mut base = DynamicImage::ImageRgb8(RgbImage::from_raw(1, 1, vec![200, 200, 200]).unwrap());
+    let top = DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![10, 20, 30, 128]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::DestOut, 1.0, false);
+    assert_eq!(base.color(), ColorType::Rgb8);
+    let px = base.to_rgb8().get_pixel(0, 0).0;
+    for c in 0..3 {
+      assert!(
+        (98..=102).contains(&px[c]),
+        "channel {c}: ~100 after half-flatten; got {}",
+        px[c]
+      );
+    }
   }
 }

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -2466,6 +2466,10 @@ fn flatten_on_black_f32(img: &mut Rgba32FImage) {
 /// One composite step: composite `top` onto `base` at the base's native depth and leave `base`
 /// as the RGBA working image (Rgba8/Rgba16/Rgba32F). Does NOT flatten or restore the color type,
 /// so chained composites keep intermediate alpha. Call `finalize_composite` once after the chain.
+///
+/// When `base` is already an RGBA working buffer (every step after the first, and any RGBA-input
+/// base) it is mutated IN PLACE — no full-frame copy. Only the first non-RGBA base is converted
+/// (copied) once to the matching depth; later steps then reuse that same backing buffer (#138).
 fn composite_step(
   base: &mut DynamicImage,
   top: &DynamicImage,
@@ -2475,23 +2479,38 @@ fn composite_step(
   opacity: f32,
   tile: bool,
 ) {
-  // Choose working depth from the base. 16-bit -> Rgba16; 32-bit float -> Rgba32F; else Rgba8.
-  match base.color() {
-    ColorType::Rgba16 | ColorType::Rgb16 | ColorType::La16 | ColorType::L16 => {
-      let mut work = base.to_rgba16();
-      composite_into_u16(&mut work, &top.to_rgba16(), x, y, mode, opacity, tile);
-      *base = DynamicImage::ImageRgba16(work);
+  match base {
+    // Already an RGBA working buffer (every step after the first, and any RGBA-input base): mutate
+    // in place — no full-frame copy. Only the top is converted (it differs each item and is small).
+    DynamicImage::ImageRgba8(work) => {
+      composite_into_u8(work, &top.to_rgba8(), x, y, mode, opacity, tile)
     }
-    ColorType::Rgb32F | ColorType::Rgba32F => {
-      let mut work = base.to_rgba32f();
-      composite_into_f32(&mut work, &top.to_rgba32f(), x, y, mode, opacity, tile);
-      *base = DynamicImage::ImageRgba32F(work);
+    DynamicImage::ImageRgba16(work) => {
+      composite_into_u16(work, &top.to_rgba16(), x, y, mode, opacity, tile)
     }
-    _ => {
-      let mut work = base.to_rgba8();
-      composite_into_u8(&mut work, &top.to_rgba8(), x, y, mode, opacity, tile);
-      *base = DynamicImage::ImageRgba8(work);
+    DynamicImage::ImageRgba32F(work) => {
+      composite_into_f32(work, &top.to_rgba32f(), x, y, mode, opacity, tile)
     }
+    // First step on a non-RGBA base: convert ONCE to the matching depth, composite, store back. The
+    // working depth follows the base's native depth (16-bit -> Rgba16, 32-bit float -> Rgba32F, else
+    // Rgba8) exactly as before; subsequent steps then hit the in-place arms above.
+    _ => match base.color() {
+      ColorType::Rgba16 | ColorType::Rgb16 | ColorType::La16 | ColorType::L16 => {
+        let mut work = base.to_rgba16();
+        composite_into_u16(&mut work, &top.to_rgba16(), x, y, mode, opacity, tile);
+        *base = DynamicImage::ImageRgba16(work);
+      }
+      ColorType::Rgb32F | ColorType::Rgba32F => {
+        let mut work = base.to_rgba32f();
+        composite_into_f32(&mut work, &top.to_rgba32f(), x, y, mode, opacity, tile);
+        *base = DynamicImage::ImageRgba32F(work);
+      }
+      _ => {
+        let mut work = base.to_rgba8();
+        composite_into_u8(&mut work, &top.to_rgba8(), x, y, mode, opacity, tile);
+        *base = DynamicImage::ImageRgba8(work);
+      }
+    },
   }
 }
 
@@ -3369,6 +3388,50 @@ mod tests {
         px.0
       );
     }
+  }
+
+  #[test]
+  fn composite_step_reuses_rgba_working_buffer_in_place() {
+    // After the first step promotes the base to an RGBA working buffer, later steps must mutate that
+    // SAME buffer instead of reallocating a full-frame copy per item (#223 perf). The old code did
+    // `*base = ImageRgba8(base.to_rgba8())` every call, which reallocates, so the backing pointer would
+    // change between steps; the in-place path keeps it stable.
+    let red = DynamicImage::ImageRgba8(RgbaImage::from_pixel(2, 2, Rgba([255, 0, 0, 255])));
+    let green = DynamicImage::ImageRgba8(RgbaImage::from_pixel(2, 2, Rgba([0, 255, 0, 255])));
+    let mut base = DynamicImage::ImageRgb8(RgbImage::from_pixel(4, 4, image::Rgb([0, 0, 0])));
+
+    // First step: converts Rgb8 -> Rgba8 (one allocation expected).
+    composite_step(&mut base, &red, 0, 0, BlendMode::Over, 1.0, false);
+    assert!(
+      matches!(base, DynamicImage::ImageRgba8(_)),
+      "promoted to Rgba8 working buffer"
+    );
+    let ptr_after_first = base.as_rgba8().unwrap().as_raw().as_ptr();
+
+    // Second step: must reuse the same backing buffer (no realloc) and composite correctly.
+    composite_step(&mut base, &green, 2, 2, BlendMode::Over, 1.0, false);
+    let ptr_after_second = base.as_rgba8().unwrap().as_raw().as_ptr();
+    assert_eq!(
+      ptr_after_first, ptr_after_second,
+      "second composite_step must mutate the buffer in place"
+    );
+
+    let img = base.to_rgba8();
+    assert_eq!(
+      img.get_pixel(0, 0).0,
+      [255, 0, 0, 255],
+      "first overlay applied"
+    );
+    assert_eq!(
+      img.get_pixel(2, 2).0,
+      [0, 255, 0, 255],
+      "second overlay applied"
+    );
+    assert_eq!(
+      img.get_pixel(0, 2).0,
+      [0, 0, 0, 255],
+      "untouched region stays black/opaque"
+    );
   }
 
   #[test]

--- a/packages/binding/src/transformer.rs
+++ b/packages/binding/src/transformer.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 
 use image::imageops::overlay;
 use image::{
-  ColorType, DynamicImage, ImageBuffer, ImageEncoder, ImageFormat, Pixel, RgbaImage,
-  imageops::FilterType,
+  ColorType, DynamicImage, ImageBuffer, ImageEncoder, ImageFormat, Pixel, Rgba, Rgba32FImage,
+  RgbaImage, imageops::FilterType,
 };
 use libavif::AvifData;
 use napi::bindgen_prelude::*;
@@ -81,6 +81,89 @@ impl TryFrom<u16> for Orientation {
       )),
     }
   }
+}
+
+#[napi]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
+/// Compositing / blending operator for `Transformer.composite`. Mirrors sharp/libvips
+/// blend modes: Porter-Duff operators plus the W3C separable blend modes.
+pub enum BlendMode {
+  /// Source-over (default) — the overlay is drawn on top of the base.
+  #[default]
+  Over,
+  /// Clear — neither source nor destination is shown.
+  Clear,
+  /// Source — only the overlay is shown.
+  Source,
+  /// Source-in — the overlay clipped to the base's shape.
+  In,
+  /// Source-out — the overlay where the base is transparent.
+  Out,
+  /// Source-atop — the overlay drawn only where the base is opaque.
+  Atop,
+  /// Destination — only the base is shown (overlay ignored).
+  Dest,
+  /// Destination-over — the base drawn on top of the overlay.
+  DestOver,
+  /// Destination-in — the base clipped to the overlay's shape.
+  DestIn,
+  /// Destination-out — the base where the overlay is transparent.
+  DestOut,
+  /// Destination-atop — the base drawn only where the overlay is opaque.
+  DestAtop,
+  /// Exclusive-or of the two coverage regions.
+  Xor,
+  /// Additive blending.
+  Add,
+  /// Saturating additive blending.
+  Saturate,
+  /// Multiply the channels.
+  Multiply,
+  /// Screen (inverse-multiply) the channels.
+  Screen,
+  /// Overlay (multiply or screen depending on the backdrop).
+  Overlay,
+  /// Keep the darker of the two channels.
+  Darken,
+  /// Keep the lighter of the two channels.
+  Lighten,
+  /// Brighten the backdrop to reflect the source.
+  ColorDodge,
+  /// Darken the backdrop to reflect the source.
+  ColorBurn,
+  /// Hard light (overlay with swapped operands).
+  HardLight,
+  /// Soft light.
+  SoftLight,
+  /// Absolute difference of the channels.
+  Difference,
+  /// Like difference but with lower contrast.
+  Exclusion,
+}
+
+#[napi]
+#[derive(Clone, Copy)]
+/// Where to anchor the overlay relative to the base image when no explicit
+/// `left`/`top` is given.
+pub enum Gravity {
+  /// Center of the base image.
+  Center,
+  /// Top edge, horizontally centered.
+  North,
+  /// Top-right corner.
+  NorthEast,
+  /// Right edge, vertically centered.
+  East,
+  /// Bottom-right corner.
+  SouthEast,
+  /// Bottom edge, horizontally centered.
+  South,
+  /// Bottom-left corner.
+  SouthWest,
+  /// Left edge, vertically centered.
+  West,
+  /// Top-left corner.
+  NorthWest,
 }
 
 #[napi]
@@ -497,6 +580,38 @@ pub struct ResizeOptions {
   pub fit: Option<ResizeFit>,
 }
 
+#[napi(object)]
+#[derive(Clone, Default)]
+pub struct CompositeOptions {
+  /// Pixel offset from the top edge. Takes precedence over `gravity` when set.
+  pub top: Option<i64>,
+  /// Pixel offset from the left edge. Takes precedence over `gravity` when set.
+  pub left: Option<i64>,
+  /// Anchor position; used only when neither `left` nor `top` is provided.
+  pub gravity: Option<Gravity>,
+  /// Blend / compositing operator. Defaults to `Over` (source-over).
+  pub blend: Option<BlendMode>,
+  /// Repeat the overlay to tile across the whole base. Ignores `left`/`top`/`gravity`.
+  pub tile: Option<bool>,
+  /// Multiply the overlay's alpha by this factor (0.0..=1.0). Fades the OVERLAY
+  /// (distinct from `Transformer.opacity`, which fades the base).
+  pub opacity: Option<f64>,
+}
+
+/// A single staged composite/overlay operation. `overlay()` and `composite()` both push one of
+/// these; the legacy `overlay()` produces the source-over, no-tile, full-opacity shape that
+/// `compute()` routes through the unchanged fast 8-bit path.
+#[derive(Clone)]
+struct CompositeItem {
+  buffer: Arc<Uint8Array>,
+  left: i64,
+  top: i64,
+  gravity: Option<Gravity>,
+  blend: BlendMode,
+  tile: bool,
+  opacity: f32, // 1.0 == no-op
+}
+
 #[derive(Default, Clone)]
 struct ImageTransformArgs {
   grayscale: bool,
@@ -512,7 +627,7 @@ struct ImageTransformArgs {
   huerotate: Option<i32>,
   orientation: Option<Orientation>,
   crop: Option<(u32, u32, u32, u32)>,
-  overlay: Vec<(Arc<Uint8Array>, i64, i64)>,
+  overlay: Vec<CompositeItem>,
   /// Multiply the alpha channel by this factor (0.0..=1.0). Promotes the image to RGBA8.
   opacity: Option<f32>,
 }
@@ -734,10 +849,31 @@ impl Task for EncodeTask {
     } else {
       let mut img = meta.image.clone();
       apply_transforms(&mut img, &self.image_transform_args, meta.orientation, true)?;
-      for (buffer, x, y) in std::mem::take(&mut self.image_transform_args.overlay).into_iter() {
-        let top = ThreadsafeDynamicImage::new(buffer.clone());
+      for item in std::mem::take(&mut self.image_transform_args.overlay).into_iter() {
+        let top = ThreadsafeDynamicImage::new(item.buffer.clone());
         let top_image_meta = top.get(true)?;
-        overlay(&mut img, &top_image_meta.image, x, y);
+        let (x, y) = resolve_position(
+          &item,
+          img.width(),
+          img.height(),
+          top_image_meta.image.width(),
+          top_image_meta.image.height(),
+        );
+        // Source-over with no tiling / full opacity keeps the fast 8-bit path (unchanged
+        // behaviour, byte-identical to `overlay`). Everything else uses the precise compositor.
+        if item.blend == BlendMode::Over && !item.tile && item.opacity == 1.0 {
+          overlay(&mut img, &top_image_meta.image, x, y);
+        } else {
+          apply_composite(
+            &mut img,
+            &top_image_meta.image,
+            x,
+            y,
+            item.blend,
+            item.opacity,
+            item.tile,
+          );
+        }
       }
       owned = img;
       &owned
@@ -1181,12 +1317,44 @@ impl Transformer {
   }
 
   #[napi]
-  /// Overlay an image at a given coordinate (x, y)
+  /// Overlay an image at a given coordinate (x, y) using source-over blending.
   pub fn overlay(&mut self, on_top: Uint8Array, x: i64, y: i64) -> Result<&Self> {
-    self
-      .image_transform_args
-      .overlay
-      .push((Arc::new(on_top), x, y));
+    self.image_transform_args.overlay.push(CompositeItem {
+      buffer: Arc::new(on_top),
+      left: x,
+      top: y,
+      gravity: None,
+      blend: BlendMode::Over,
+      tile: false,
+      opacity: 1.0,
+    });
+    Ok(self)
+  }
+
+  #[napi]
+  /// Composite `on_top` onto this image with a sharp-style blend mode, gravity-based
+  /// positioning, tiling, and per-overlay opacity. See `CompositeOptions`.
+  ///
+  /// Source-over (`blend: Over`, no tiling, full opacity) composites at 8-bit, identical
+  /// to `overlay`. Other blend modes / tiling / opacity < 1 run at the base image's native
+  /// channel depth (8/16-bit, or 32-bit float), then the result is converted back to the
+  /// base's original color type — so an opaque base never gains an alpha channel, and
+  /// alpha-reducing modes (Clear/Out/DestOut/Xor) have no visible effect on an opaque base.
+  pub fn composite(
+    &mut self,
+    on_top: Uint8Array,
+    options: Option<CompositeOptions>,
+  ) -> Result<&Self> {
+    let o = options.unwrap_or_default();
+    self.image_transform_args.overlay.push(CompositeItem {
+      buffer: Arc::new(on_top),
+      left: o.left.unwrap_or(0),
+      top: o.top.unwrap_or(0),
+      gravity: o.gravity,
+      blend: o.blend.unwrap_or_default(),
+      tile: o.tile.unwrap_or(false),
+      opacity: (o.opacity.unwrap_or(1.0) as f32).clamp(0.0, 1.0),
+    });
     Ok(self)
   }
 
@@ -1735,6 +1903,413 @@ fn apply_opacity(image: &mut DynamicImage, factor: f32) {
   }
 }
 
+/// Resolve the top-left placement of an overlay. Explicit `left`/`top` take precedence over
+/// `gravity` (sharp semantics): gravity is honored only when it is set AND both offsets are 0.
+/// Computed in i64; negative results are valid (the overlay is clipped by the compositor).
+fn resolve_position(item: &CompositeItem, bw: u32, bh: u32, tw: u32, th: u32) -> (i64, i64) {
+  if item.left != 0 || item.top != 0 || item.gravity.is_none() {
+    // explicit offset (or default 0,0 when neither offset nor gravity given)
+    return (item.left, item.top);
+  }
+  let (bw, bh, tw, th) = (bw as i64, bh as i64, tw as i64, th as i64);
+  let cx = (bw - tw) / 2;
+  let cy = (bh - th) / 2;
+  let right = bw - tw;
+  let bottom = bh - th;
+  match item.gravity.unwrap() {
+    Gravity::NorthWest => (0, 0),
+    Gravity::North => (cx, 0),
+    Gravity::NorthEast => (right, 0),
+    Gravity::West => (0, cy),
+    Gravity::Center => (cx, cy),
+    Gravity::East => (right, cy),
+    Gravity::SouthWest => (0, bottom),
+    Gravity::South => (cx, bottom),
+    Gravity::SouthEast => (right, bottom),
+  }
+}
+
+// --- Blend math core (W3C "Compositing and Blending Level 1"). All channels are straight-alpha
+// f32 in [0,1]; `cb` is the backdrop, `cs` the source. ---
+
+fn color_dodge(cb: f32, cs: f32) -> f32 {
+  if cb == 0.0 {
+    0.0
+  } else if cs == 1.0 {
+    1.0
+  } else {
+    (cb / (1.0 - cs)).min(1.0)
+  }
+}
+
+fn color_burn(cb: f32, cs: f32) -> f32 {
+  if cb == 1.0 {
+    1.0
+  } else if cs == 0.0 {
+    0.0
+  } else {
+    1.0 - ((1.0 - cb) / cs).min(1.0)
+  }
+}
+
+fn hard_light(cb: f32, cs: f32) -> f32 {
+  if cs <= 0.5 {
+    2.0 * cb * cs
+  } else {
+    let d = 2.0 * cs - 1.0;
+    cb + d - cb * d
+  }
+}
+
+fn soft_light(cb: f32, cs: f32) -> f32 {
+  let d = if cb <= 0.25 {
+    ((16.0 * cb - 12.0) * cb + 4.0) * cb
+  } else {
+    cb.sqrt()
+  };
+  if cs <= 0.5 {
+    cb - (1.0 - 2.0 * cs) * cb * (1.0 - cb)
+  } else {
+    cb + (2.0 * cs - 1.0) * (d - cb)
+  }
+}
+
+/// Separable blend `B(cb, cs)`. Returns `None` for Porter-Duff-only modes (identity = `cs`).
+fn separable_blend(mode: BlendMode, cb: f32, cs: f32) -> Option<f32> {
+  Some(match mode {
+    BlendMode::Multiply => cb * cs,
+    BlendMode::Screen => cb + cs - cb * cs,
+    BlendMode::Overlay => hard_light(cs, cb), // NOTE the swapped args
+    BlendMode::Darken => cb.min(cs),
+    BlendMode::Lighten => cb.max(cs),
+    BlendMode::ColorDodge => color_dodge(cb, cs),
+    BlendMode::ColorBurn => color_burn(cb, cs),
+    BlendMode::HardLight => hard_light(cb, cs),
+    BlendMode::SoftLight => soft_light(cb, cs),
+    BlendMode::Difference => (cb - cs).abs(),
+    BlendMode::Exclusion => cb + cs - 2.0 * cb * cs,
+    _ => return None,
+  })
+}
+
+/// Porter-Duff coefficients `(Fa, Fb)`. Separable modes (and `Over`) use source-over.
+fn pd_coeffs(mode: BlendMode, a_s: f32, ab: f32) -> (f32, f32) {
+  match mode {
+    BlendMode::Clear => (0.0, 0.0),
+    BlendMode::Source => (1.0, 0.0),
+    BlendMode::Dest => (0.0, 1.0),
+    BlendMode::DestOver => (1.0 - ab, 1.0),
+    BlendMode::In => (ab, 0.0),
+    BlendMode::DestIn => (0.0, a_s),
+    BlendMode::Out => (1.0 - ab, 0.0),
+    BlendMode::DestOut => (0.0, 1.0 - a_s),
+    BlendMode::Atop => (ab, 1.0 - a_s),
+    BlendMode::DestAtop => (1.0 - ab, a_s),
+    BlendMode::Xor => (1.0 - ab, 1.0 - a_s),
+    BlendMode::Add => (1.0, 1.0),
+    BlendMode::Saturate => (
+      if a_s > 0.0 {
+        (1.0 - ab).min(a_s) / a_s
+      } else {
+        0.0
+      },
+      1.0,
+    ),
+    // Over + all separable modes composite with source-over coefficients.
+    _ => (1.0, 1.0 - a_s),
+  }
+}
+
+/// Blend one source pixel over one backdrop pixel. All channels straight-alpha `[0,1]`.
+fn blend_rgba_f32(cb: [f32; 4], cs: [f32; 4], mode: BlendMode, opacity: f32) -> [f32; 4] {
+  let ab = cb[3];
+  let a_s = (cs[3] * opacity).clamp(0.0, 1.0);
+  let (fa, fb) = pd_coeffs(mode, a_s, ab);
+  let ao = (a_s * fa + ab * fb).clamp(0.0, 1.0);
+  let mut out = [0.0f32; 4];
+  for c in 0..3 {
+    let b = separable_blend(mode, cb[c], cs[c]).unwrap_or(cs[c]);
+    let cs_blended = (1.0 - ab) * cs[c] + ab * b;
+    let co = a_s * fa * cs_blended + ab * fb * cb[c]; // premultiplied
+    out[c] = if ao > 0.0 {
+      (co / ao).clamp(0.0, 1.0)
+    } else {
+      0.0
+    };
+  }
+  out[3] = ao;
+  out
+}
+
+/// Clamp/normalize an f32 channel into `[0,1]`, sanitizing NaN to 0.0 (mirrors `apply_opacity`'s
+/// NaN handling). HDR values outside the unit range are clamped for blending.
+#[inline]
+fn norm_f32(v: f32) -> f32 {
+  if v.is_nan() { 0.0 } else { v.clamp(0.0, 1.0) }
+}
+
+/// Overlap rectangle of `top` placed at `(x, y)` over a `bw x bh` base, clamped exactly like the
+/// `image` crate's `overlay_bounds_ext` (handles negative offsets and tops larger than the base).
+/// Returns `(origin_bottom_x, origin_bottom_y, origin_top_x, origin_top_y, x_range, y_range)`.
+fn overlap_bounds(
+  bw: u32,
+  bh: u32,
+  tw: u32,
+  th: u32,
+  x: i64,
+  y: i64,
+) -> (u32, u32, u32, u32, u32, u32) {
+  if x > i64::from(bw)
+    || y > i64::from(bh)
+    || x.saturating_add(i64::from(tw)) <= 0
+    || y.saturating_add(i64::from(th)) <= 0
+  {
+    return (0, 0, 0, 0, 0, 0);
+  }
+  let max_x = x.saturating_add(i64::from(tw));
+  let max_y = y.saturating_add(i64::from(th));
+  let max_inbounds_x = max_x.clamp(0, i64::from(bw)) as u32;
+  let max_inbounds_y = max_y.clamp(0, i64::from(bh)) as u32;
+  let origin_bottom_x = x.clamp(0, i64::from(bw)) as u32;
+  let origin_bottom_y = y.clamp(0, i64::from(bh)) as u32;
+  let x_range = max_inbounds_x - origin_bottom_x;
+  let y_range = max_inbounds_y - origin_bottom_y;
+  let origin_top_x = x.saturating_mul(-1).clamp(0, i64::from(tw)) as u32;
+  let origin_top_y = y.saturating_mul(-1).clamp(0, i64::from(th)) as u32;
+  (
+    origin_bottom_x,
+    origin_bottom_y,
+    origin_top_x,
+    origin_top_y,
+    x_range,
+    y_range,
+  )
+}
+
+/// Placement offsets for an overlay. A single `(x, y)` normally; for tiling, top-left origins
+/// stepping by the overlay size across the whole base starting at `(0, 0)` (ignoring `x/y`).
+fn placement_offsets(
+  tile: bool,
+  bw: u32,
+  bh: u32,
+  tw: u32,
+  th: u32,
+  x: i64,
+  y: i64,
+) -> Vec<(i64, i64)> {
+  if !tile {
+    return vec![(x, y)];
+  }
+  let mut offsets = Vec::new();
+  // Caller guards `tw > 0 && th > 0`; keep a defensive check so the loop always terminates.
+  if tw == 0 || th == 0 {
+    return offsets;
+  }
+  let mut oy = 0u32;
+  while oy < bh {
+    let mut ox = 0u32;
+    while ox < bw {
+      offsets.push((ox as i64, oy as i64));
+      ox += tw;
+    }
+    oy += th;
+  }
+  offsets
+}
+
+/// Composite `top` onto an 8-bit RGBA `base` in place. Channels normalize `/255`, denormalize
+/// `(v*255).round().clamp(0,255)` (the same rounding idiom as `apply_opacity`).
+fn composite_into_u8(
+  base: &mut RgbaImage,
+  top: &RgbaImage,
+  x: i64,
+  y: i64,
+  mode: BlendMode,
+  opacity: f32,
+  tile: bool,
+) {
+  let (bw, bh) = (base.width(), base.height());
+  let (tw, th) = (top.width(), top.height());
+  if tw == 0 || th == 0 {
+    return;
+  }
+  for (ox, oy) in placement_offsets(tile, bw, bh, tw, th, x, y) {
+    let (obx, oby, otx, oty, rw, rh) = overlap_bounds(bw, bh, tw, th, ox, oy);
+    for ry in 0..rh {
+      for rx in 0..rw {
+        let s = top.get_pixel(otx + rx, oty + ry).0;
+        let cs = [
+          s[0] as f32 / 255.0,
+          s[1] as f32 / 255.0,
+          s[2] as f32 / 255.0,
+          s[3] as f32 / 255.0,
+        ];
+        let d = base.get_pixel(obx + rx, oby + ry).0;
+        let cb = [
+          d[0] as f32 / 255.0,
+          d[1] as f32 / 255.0,
+          d[2] as f32 / 255.0,
+          d[3] as f32 / 255.0,
+        ];
+        let out = blend_rgba_f32(cb, cs, mode, opacity);
+        base.put_pixel(
+          obx + rx,
+          oby + ry,
+          Rgba([
+            (out[0] * 255.0).round().clamp(0.0, 255.0) as u8,
+            (out[1] * 255.0).round().clamp(0.0, 255.0) as u8,
+            (out[2] * 255.0).round().clamp(0.0, 255.0) as u8,
+            (out[3] * 255.0).round().clamp(0.0, 255.0) as u8,
+          ]),
+        );
+      }
+    }
+  }
+}
+
+/// Composite `top` onto a 16-bit RGBA `base` in place. Channels normalize `/65535`, denormalize
+/// `(v*65535).round().clamp(0,65535)`.
+fn composite_into_u16(
+  base: &mut ImageBuffer<Rgba<u16>, Vec<u16>>,
+  top: &ImageBuffer<Rgba<u16>, Vec<u16>>,
+  x: i64,
+  y: i64,
+  mode: BlendMode,
+  opacity: f32,
+  tile: bool,
+) {
+  let (bw, bh) = (base.width(), base.height());
+  let (tw, th) = (top.width(), top.height());
+  if tw == 0 || th == 0 {
+    return;
+  }
+  for (ox, oy) in placement_offsets(tile, bw, bh, tw, th, x, y) {
+    let (obx, oby, otx, oty, rw, rh) = overlap_bounds(bw, bh, tw, th, ox, oy);
+    for ry in 0..rh {
+      for rx in 0..rw {
+        let s = top.get_pixel(otx + rx, oty + ry).0;
+        let cs = [
+          s[0] as f32 / 65535.0,
+          s[1] as f32 / 65535.0,
+          s[2] as f32 / 65535.0,
+          s[3] as f32 / 65535.0,
+        ];
+        let d = base.get_pixel(obx + rx, oby + ry).0;
+        let cb = [
+          d[0] as f32 / 65535.0,
+          d[1] as f32 / 65535.0,
+          d[2] as f32 / 65535.0,
+          d[3] as f32 / 65535.0,
+        ];
+        let out = blend_rgba_f32(cb, cs, mode, opacity);
+        base.put_pixel(
+          obx + rx,
+          oby + ry,
+          Rgba([
+            (out[0] * 65535.0).round().clamp(0.0, 65535.0) as u16,
+            (out[1] * 65535.0).round().clamp(0.0, 65535.0) as u16,
+            (out[2] * 65535.0).round().clamp(0.0, 65535.0) as u16,
+            (out[3] * 65535.0).round().clamp(0.0, 65535.0) as u16,
+          ]),
+        );
+      }
+    }
+  }
+}
+
+/// Composite `top` onto a 32-bit float RGBA `base` in place. Channels are clamped to `[0,1]` for
+/// blending (HDR values outside the unit range are clamped, NaN sanitized to 0.0); the blended
+/// result is already clamped to `[0,1]`, so it is written directly.
+fn composite_into_f32(
+  base: &mut Rgba32FImage,
+  top: &Rgba32FImage,
+  x: i64,
+  y: i64,
+  mode: BlendMode,
+  opacity: f32,
+  tile: bool,
+) {
+  let (bw, bh) = (base.width(), base.height());
+  let (tw, th) = (top.width(), top.height());
+  if tw == 0 || th == 0 {
+    return;
+  }
+  for (ox, oy) in placement_offsets(tile, bw, bh, tw, th, x, y) {
+    let (obx, oby, otx, oty, rw, rh) = overlap_bounds(bw, bh, tw, th, ox, oy);
+    for ry in 0..rh {
+      for rx in 0..rw {
+        let s = top.get_pixel(otx + rx, oty + ry).0;
+        let cs = [
+          norm_f32(s[0]),
+          norm_f32(s[1]),
+          norm_f32(s[2]),
+          norm_f32(s[3]),
+        ];
+        let d = base.get_pixel(obx + rx, oby + ry).0;
+        let cb = [
+          norm_f32(d[0]),
+          norm_f32(d[1]),
+          norm_f32(d[2]),
+          norm_f32(d[3]),
+        ];
+        let out = blend_rgba_f32(cb, cs, mode, opacity);
+        base.put_pixel(obx + rx, oby + ry, Rgba(out));
+      }
+    }
+  }
+}
+
+/// Convert the composited RGBA `DynamicImage` back to the base's `original` color family, so an
+/// opaque base never gains an alpha channel and `metadata().colorType` stays accurate. Falls back
+/// to the RGBA image (of the working depth) for any color type not separately handled.
+fn restore_color_type(img: DynamicImage, original: ColorType) -> DynamicImage {
+  match original {
+    ColorType::L8 => DynamicImage::ImageLuma8(img.to_luma8()),
+    ColorType::La8 => DynamicImage::ImageLumaA8(img.to_luma_alpha8()),
+    ColorType::Rgb8 => DynamicImage::ImageRgb8(img.to_rgb8()),
+    ColorType::Rgba8 => img,
+    ColorType::L16 => DynamicImage::ImageLuma16(img.to_luma16()),
+    ColorType::La16 => DynamicImage::ImageLumaA16(img.to_luma_alpha16()),
+    ColorType::Rgb16 => DynamicImage::ImageRgb16(img.to_rgb16()),
+    ColorType::Rgba16 => img,
+    ColorType::Rgb32F => DynamicImage::ImageRgb32F(img.to_rgb32f()),
+    ColorType::Rgba32F => img,
+    _ => img,
+  }
+}
+
+/// Composite `top` onto `base` at `(x, y)` (or tiled) with `mode`/`opacity`. Works at the base's
+/// native channel depth (8/16-bit or 32-bit float), then restores the base's ORIGINAL color type.
+fn apply_composite(
+  base: &mut DynamicImage,
+  top: &DynamicImage,
+  x: i64,
+  y: i64,
+  mode: BlendMode,
+  opacity: f32,
+  tile: bool,
+) {
+  let original = base.color();
+  // Choose working depth from the base. 16-bit -> Rgba16; 32-bit float -> Rgba32F; else Rgba8.
+  match original {
+    ColorType::Rgba16 | ColorType::Rgb16 | ColorType::La16 | ColorType::L16 => {
+      let mut work = base.to_rgba16();
+      composite_into_u16(&mut work, &top.to_rgba16(), x, y, mode, opacity, tile);
+      *base = restore_color_type(DynamicImage::ImageRgba16(work), original);
+    }
+    ColorType::Rgb32F | ColorType::Rgba32F => {
+      let mut work = base.to_rgba32f();
+      composite_into_f32(&mut work, &top.to_rgba32f(), x, y, mode, opacity, tile);
+      *base = restore_color_type(DynamicImage::ImageRgba32F(work), original);
+    }
+    _ => {
+      let mut work = base.to_rgba8();
+      composite_into_u8(&mut work, &top.to_rgba8(), x, y, mode, opacity, tile);
+      *base = restore_color_type(DynamicImage::ImageRgba8(work), original);
+    }
+  }
+}
+
 #[inline]
 fn parse_exif(
   buf: &[u8],
@@ -1813,9 +2388,10 @@ mod tests {
   }
 
   use super::{
-    ImageTransformArgs, apply_contrast, apply_huerotate, apply_opacity, apply_transforms,
+    BlendMode, ImageTransformArgs, apply_composite, apply_contrast, apply_huerotate, apply_opacity,
+    apply_transforms,
   };
-  use image::{ColorType, DynamicImage, ImageBuffer, RgbaImage};
+  use image::{ColorType, DynamicImage, ImageBuffer, RgbImage, RgbaImage};
 
   #[test]
   fn huerotate_preserves_16bit_color_through_pipeline() {
@@ -1888,7 +2464,10 @@ mod tests {
     );
     apply_huerotate(&mut img, 90);
     let px = img.to_rgba16().get_pixel(0, 0).0;
-    assert_eq!(px[3], 50000, "16-bit alpha must pass through, not clamp to 255");
+    assert_eq!(
+      px[3], 50000,
+      "16-bit alpha must pass through, not clamp to 255"
+    );
     assert!(
       px[0] as u32 + px[1] as u32 + px[2] as u32 > 1000,
       "16-bit color must not be crushed to ~255; got {px:?}"
@@ -1901,9 +2480,8 @@ mod tests {
     // opacity output. `apply_contrast` never touches alpha, so the alpha that reaches
     // `apply_opacity` is identical whether or not a no-op contrast is staged; opacity then
     // normalizes it the same way in both paths. Codex adversarial review on #42.
-    let base = DynamicImage::ImageRgba32F(
-      ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap(),
-    );
+    let base =
+      DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap());
     let alpha_of = |contrast: Option<f32>| {
       let mut img = base.clone();
       let args = ImageTransformArgs {
@@ -1947,9 +2525,8 @@ mod tests {
     // so an HDR channel must survive — never clipped to 1.0. The crate clamped float to
     // 255, so it preserved these; our depth-aware impl must not regress. Guards the Codex
     // adversarial review on #42.
-    let mut img = DynamicImage::ImageRgba32F(
-      ImageBuffer::from_raw(1, 1, vec![2.5f32, 0.3, 1.8, 4.0]).unwrap(),
-    );
+    let mut img =
+      DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![2.5f32, 0.3, 1.8, 4.0]).unwrap());
     apply_huerotate(&mut img, 0);
     if let DynamicImage::ImageRgba32F(buf) = &img {
       let p = buf.get_pixel(0, 0).0;
@@ -1959,7 +2536,11 @@ mod tests {
         p[0]
       );
       assert!((p[1] - 0.3).abs() < 1e-4, "G survives; got {}", p[1]);
-      assert!((p[2] - 1.8).abs() < 1e-4, "HDR B must survive; got {}", p[2]);
+      assert!(
+        (p[2] - 1.8).abs() < 1e-4,
+        "HDR B must survive; got {}",
+        p[2]
+      );
       assert!((p[3] - 4.0).abs() < 1e-6, "alpha untouched; got {}", p[3]);
     } else {
       panic!("expected Rgba32F");
@@ -1970,12 +2551,15 @@ mod tests {
   fn huerotate_leaves_grayscale_luma_unchanged() {
     // Grayscale has no hue, so rotating it is a no-op on luma (the crate emitted garbage
     // by treating luma/alpha as RGB). Alpha is preserved too.
-    let mut img =
-      DynamicImage::ImageLumaA8(ImageBuffer::from_raw(1, 1, vec![120u8, 200]).unwrap());
+    let mut img = DynamicImage::ImageLumaA8(ImageBuffer::from_raw(1, 1, vec![120u8, 200]).unwrap());
     apply_huerotate(&mut img, 90);
     assert_eq!(img.color(), ColorType::La8, "grayscale stays grayscale");
     if let DynamicImage::ImageLumaA8(buf) = &img {
-      assert_eq!(buf.get_pixel(0, 0).0, [120, 200], "luma and alpha unchanged");
+      assert_eq!(
+        buf.get_pixel(0, 0).0,
+        [120, 200],
+        "luma and alpha unchanged"
+      );
     } else {
       panic!("expected LumaA8");
     }
@@ -1999,7 +2583,11 @@ mod tests {
       apply_transforms(&mut img, &args, None, true).unwrap();
       img.to_rgba8().get_pixel(0, 0).0[3]
     };
-    assert_eq!(alpha(None), 200, "contrast alone must leave alpha untouched");
+    assert_eq!(
+      alpha(None),
+      200,
+      "contrast alone must leave alpha untouched"
+    );
     assert_eq!(alpha(Some(1.0)), 200, "opacity(1) must be a true no-op");
     assert_eq!(
       alpha(None),
@@ -2113,19 +2701,24 @@ mod tests {
       DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap());
     apply_opacity(&mut img, 1.0);
     let identity = img.to_rgba32f().get_pixel(0, 0).0[3];
-    assert_eq!(identity, 1.0, "4.0 normalizes to full opacity; got {identity}");
+    assert_eq!(
+      identity, 1.0,
+      "4.0 normalizes to full opacity; got {identity}"
+    );
 
     // ...and a real fade still bites: normalize 4.0 -> 1.0, then * 0.5 -> 0.5 (NOT 1.0).
     let mut img =
       DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 4.0]).unwrap());
     apply_opacity(&mut img, 0.5);
     let faded = img.to_rgba32f().get_pixel(0, 0).0[3];
-    assert_eq!(faded, 0.5, "opacity(0.5) must still fade out-of-range alpha; got {faded}");
+    assert_eq!(
+      faded, 0.5,
+      "opacity(0.5) must still fade out-of-range alpha; got {faded}"
+    );
 
     // In-range source: new = old * factor, unchanged by the normalization.
-    let mut img = DynamicImage::ImageRgba32F(
-      ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 0.8]).unwrap(),
-    );
+    let mut img =
+      DynamicImage::ImageRgba32F(ImageBuffer::from_raw(1, 1, vec![0.2f32, 0.3, 0.4, 0.8]).unwrap());
     apply_opacity(&mut img, 0.5);
     let in_range = img.to_rgba32f().get_pixel(0, 0).0[3];
     assert!(
@@ -2218,9 +2811,16 @@ mod tests {
       img.to_rgba8().get_pixel(0, 0).0
     };
     let crate_px = base.adjust_contrast(60.0).to_rgba8().get_pixel(0, 0).0;
-    assert_eq!(mine[0..3], crate_px[0..3], "color channels must match the crate");
+    assert_eq!(
+      mine[0..3],
+      crate_px[0..3],
+      "color channels must match the crate"
+    );
     assert_eq!(mine[3], 200, "alpha must be preserved");
-    assert_ne!(crate_px[3], 200, "sanity: the crate's adjust_contrast does mangle this alpha");
+    assert_ne!(
+      crate_px[3], 200,
+      "sanity: the crate's adjust_contrast does mangle this alpha"
+    );
   }
 
   #[test]
@@ -2268,6 +2868,102 @@ mod tests {
     assert_eq!(
       without, with_noop_contrast,
       "a no-op contrast(0) must not change huerotate output (LumaA must not be promoted early)"
+    );
+  }
+
+  #[test]
+  fn composite_multiply_halves_gray() {
+    // round(0.502^2 * 255) = 64. Multiply of two mid-grays.
+    let mut base =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![128, 128, 128, 255]).unwrap());
+    let top =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![128, 128, 128, 255]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Multiply, 1.0, false);
+    assert_eq!(base.color(), ColorType::Rgba8);
+    assert_eq!(base.to_rgba8().get_pixel(0, 0).0, [64, 64, 64, 255]);
+  }
+
+  #[test]
+  fn composite_color_dodge_saturates_without_nan() {
+    // cs == 1.0 hits the ColorDodge guard: channels saturate to 255, no NaN/panic.
+    let mut base =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![128, 128, 128, 255]).unwrap());
+    let top =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![255, 255, 255, 255]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::ColorDodge, 1.0, false);
+    assert_eq!(base.to_rgba8().get_pixel(0, 0).0, [255, 255, 255, 255]);
+  }
+
+  #[test]
+  fn composite_dest_over_keeps_opaque_backdrop() {
+    // DestOver onto an opaque backdrop: Fa = 1 - ab = 0, so the base shows through unchanged.
+    let mut base =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![255, 0, 0, 255]).unwrap());
+    let top = DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![0, 0, 255, 255]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::DestOver, 1.0, false);
+    assert_eq!(base.to_rgba8().get_pixel(0, 0).0, [255, 0, 0, 255]);
+  }
+
+  #[test]
+  fn composite_over_matches_legacy_overlay_within_one() {
+    // The custom `Over` path must match `image::imageops::overlay` within ±1 per channel
+    // (rounding vs truncation).
+    let base = DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![0, 0, 255, 255]).unwrap());
+    let top = DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![255, 0, 0, 128]).unwrap());
+
+    let legacy = {
+      let mut b = base.clone();
+      image::imageops::overlay(&mut b, &top, 0, 0);
+      b.to_rgba8().get_pixel(0, 0).0
+    };
+    let custom = {
+      let mut b = base.clone();
+      apply_composite(&mut b, &top, 0, 0, BlendMode::Over, 1.0, false);
+      b.to_rgba8().get_pixel(0, 0).0
+    };
+    for c in 0..4 {
+      let diff = (legacy[c] as i32 - custom[c] as i32).abs();
+      assert!(
+        diff <= 1,
+        "channel {c}: legacy {} vs custom {} differ by {diff} (> 1)",
+        legacy[c],
+        custom[c]
+      );
+    }
+  }
+
+  #[test]
+  fn composite_tile_covers_whole_base() {
+    // A 2x2 opaque overlay tiled over a 4x4 base must paint every pixel.
+    let mut base = DynamicImage::ImageRgba8(
+      RgbaImage::from_raw(4, 4, vec![50, 60, 70, 255].repeat(16)).unwrap(),
+    );
+    let top =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(2, 2, vec![10, 20, 30, 255].repeat(4)).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Over, 1.0, true);
+    let out = base.to_rgba8();
+    for y in 0..4 {
+      for x in 0..4 {
+        assert_eq!(
+          out.get_pixel(x, y).0,
+          [10, 20, 30, 255],
+          "tile must cover pixel ({x}, {y})"
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn composite_preserves_opaque_color_type() {
+    // An opaque RGB8 base must NOT gain an alpha channel after compositing.
+    let mut base = DynamicImage::ImageRgb8(RgbImage::from_raw(1, 1, vec![100, 150, 200]).unwrap());
+    let top =
+      DynamicImage::ImageRgba8(RgbaImage::from_raw(1, 1, vec![128, 128, 128, 255]).unwrap());
+    apply_composite(&mut base, &top, 0, 0, BlendMode::Multiply, 1.0, false);
+    assert_eq!(
+      base.color(),
+      ColorType::Rgb8,
+      "opaque base must stay Rgb8 (no alpha channel added)"
     );
   }
 }


### PR DESCRIPTION
Closes #138.

Adds a chainable `composite()` method to `Transformer` for sharp-style compositing, so users migrating off `sharp` (which needs `node-gyp`) can layer images with blend modes, gravity positioning, and tiling. Legacy `overlay()` is untouched and byte-identical.

## API

```ts
.composite(onTop: Uint8Array, options?: CompositeOptions): this

interface CompositeOptions {
  top?: number      // pixel offset (provide WITH left, or neither — sharp parity)
  left?: number
  gravity?: Gravity // anchor; default Center; used when no offset given
  blend?: BlendMode // default Over
  tile?: boolean    // repeat to fill, phased by offset/gravity
  opacity?: number  // 0..1, fades the OVERLAY (distinct from .opacity() on the base)
}
```

- **`BlendMode`** — full sharp/libvips parity surface: Porter-Duff operators (Clear, Source, Over, In, Out, Atop, Dest, DestOver, DestIn, DestOut, DestAtop, Xor, Add, Saturate) + W3C separable modes (Multiply, Screen, Overlay, Darken, Lighten, ColorDodge, ColorBurn, HardLight, SoftLight, Difference, Exclusion).
- **`Gravity`** — Center (default), North, NorthEast, East, SouthEast, South, SouthWest, West, NorthWest.

## Behavior

- **Placement (sharp parity):** explicit `left`/`top` win over `gravity`; default placement is the base centre; supplying only one of `left`/`top` is an error; an overlay larger than the base is rejected (`Image to composite must have same dimensions or smaller`), while legacy `overlay()` keeps clipping.
- **Depth:** source-over (`Over`, no tile, full opacity) keeps the existing 8-bit fast path; blend modes / tiling / `opacity < 1` composite at the base's native depth (8/16-bit or 32-bit float). The base's original color type is preserved (an opaque base never gains an alpha channel; metadata is unaffected); coverage-reducing modes flatten onto black.
- **Tiling** is streamed (no per-tile allocation) and phased by the resolved offset/gravity.
- **Blend math** follows the W3C "Compositing and Blending Level 1" model (same as CSS `mix-blend-mode` / SVG / Canvas). Results match sharp/libvips for opaque inputs and for `Over` at any alpha; translucent inputs through a separable blend mode differ from sharp's premultiplied-alpha math (documented).

## Tests

- Rust unit tests for the blend math, Porter-Duff coefficients, per-depth paths (8/16-bit, 32F), gravity resolution, tiling, color-type preservation, and HDR no-op preservation.
- JS e2e (ava): Multiply, Gravity.SouthEast, tile coverage, DestOver, opacity, default-centre placement, one-sided-offset rejection, NaN-opacity sanitization, oversized-overlay rejection.
- `cargo test` 164 passed · `yarn test` 103 passed / 9 skipped (wasi-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new compositing path in the core Rust transform/encode pipeline with many blend modes and sharp-parity edge cases; legacy `overlay()` is preserved but mixed chains change behavior when any `composite()` is present.
> 
> **Overview**
> Adds **sharp-style `Transformer.composite()`** alongside unchanged legacy **`overlay()`**, exporting **`BlendMode`**, **`Gravity`**, and **`CompositeOptions`** through the NAPI bindings (including WASI shims and generated **`index.d.ts`**). Native binding version checks move to **1.14.0**.
> 
> The encode pipeline now stages overlays as **`CompositeItem`** entries: **`composite()`** validates placement (paired **`left`/`top`**, default center gravity, rejects oversized layers), runs W3C/CSS blend math at the base’s native depth (8/16/f32), supports tiling and per-overlay opacity, and **defers flatten/restore** until after the full chain so intermediate alpha survives mixed **`composite()`** / **`overlay()`** sequences. Pure **`overlay()`**-only chains keep the existing byte-identical 8-bit path.
> 
> README gains a **`composite()`** example and blend-semantics note; AVA and Rust unit tests cover modes, gravity, tiling, sharp parity edges, and chaining.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159ce7c97b6536e5dd787d3a68789dd78667beb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->