### PR TITLE
fix(playground): accept SVG input

### DIFF
--- a/website/e2e/fixtures/ns-prefixed.svg
+++ b/website/e2e/fixtures/ns-prefixed.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:svg xmlns:s="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <s:rect width="64" height="64" fill="#cc5500"/>
+  <s:circle cx="32" cy="32" r="20" fill="#1a1a1a"/>
+</s:svg>

--- a/website/e2e/playground-svg.spec.ts
+++ b/website/e2e/playground-svg.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect, type Page } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+// SVG exercises the vector-only decode path: the generic `new Transformer(bytes)` constructor
+// routes through `image::guess_format` (no SVG signature) and throws, so the worker must sniff
+// SVG and rasterize via `Transformer.fromSvg`.
+const dir = path.dirname(fileURLToPath(import.meta.url))
+// The playground's own sample SVG (default `<svg xmlns=...>` root), served from public/.
+const PLAIN_SVG = path.resolve(dir, '../public/img/input-debian.svg')
+// A namespace-prefixed root (`<s:svg xmlns:s=...>`): valid SVG that `fromSvg` decodes but a naive
+// `includes('<svg')` sniffer would miss. Regression guard for the byte sniffer.
+const NS_PREFIXED_SVG = path.resolve(dir, 'fixtures/ns-prefixed.svg')
+
+// Upload a file and wait for the worker to decode its metadata (status -> "idle", no error).
+// `vite dev` pre-bundles the wasm worker's deps the first time the engine imports them, which
+// forces a one-time full page reload (status resets to "empty"); retry the upload so that reload
+// can't flake the run. Before the fix the worker called `new Transformer(svgBytes)`, which failed
+// with "Guess format ... failed", so status never reached "idle".
+async function uploadAndDecode(page: Page, fixture: string) {
+  const status = page.getByTestId('pg-status')
+  await expect(async () => {
+    await page.locator('input[type=file]').setInputFiles(fixture)
+    await expect(status).toHaveAttribute('data-status', 'idle', { timeout: 20_000 })
+  }).toPass({ timeout: 90_000 })
+  await expect(page.getByTestId('pg-error')).toHaveCount(0)
+}
+
+async function openPlayground(page: Page) {
+  page.on('console', (msg) => console.log(`[browser:${msg.type()}] ${msg.text()}`))
+  page.on('pageerror', (err) => console.log(`[pageerror] ${err.message}`))
+  await page.goto('/playground')
+  await expect
+    .poll(() => page.evaluate(() => self.crossOriginIsolated), { timeout: 30_000 })
+    .toBe(true)
+}
+
+test('playground decodes an SVG, reports its format, and converts it', async ({ page }) => {
+  await openPlayground(page)
+  await uploadAndDecode(page, PLAIN_SVG)
+
+  // fromSvg reports format "svg": the metadata line shows it, and that string gates the Compress
+  // tab (only jpeg/png inputs are compressible). If the binding mislabeled SVG as png/jpeg, the
+  // Compress codecs would run on raw SVG bytes and fail — so assert the tab stays disabled.
+  await expect(page.getByText(/·\s*SVG/).first()).toBeVisible()
+  await page.getByRole('tab', { name: 'Compress' }).click()
+  await expect(page.getByText(/supports JPEG and PNG inputs/i)).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Run' })).toBeDisabled()
+
+  // Convert (the default-supported op) must produce real output bytes.
+  await page.getByRole('tab', { name: 'Convert' }).click()
+  const runButton = page.getByRole('button', { name: 'Run' })
+  await expect(runButton).toBeEnabled({ timeout: 30_000 })
+  await runButton.click()
+
+  await expect(page.getByTestId('pg-status')).toHaveAttribute('data-status', 'done', {
+    timeout: 120_000,
+  })
+  const text = await page.getByTestId('pg-bytes').innerText()
+  expect(Number(text.match(/(\d+) bytes/)?.[1] ?? 0)).toBeGreaterThan(0)
+
+  // The copyable snippet must reflect the SVG decode path the playground actually used, so a user
+  // who copies it gets runnable code (`new Transformer(svg)` would throw "Guess format ... failed").
+  await expect(page.getByTestId('pg-result')).toContainText('Transformer.fromSvg(input)')
+})
+
+test('playground decodes a namespace-prefixed SVG root', async ({ page }) => {
+  await openPlayground(page)
+  // `<s:svg xmlns:s=...>` must still be sniffed as SVG and routed through fromSvg, not rejected
+  // by the generic constructor's format guess.
+  await uploadAndDecode(page, NS_PREFIXED_SVG)
+  await expect(page.getByText(/·\s*SVG/).first()).toBeVisible()
+})

--- a/website/pages/playground/_Playground.tsx
+++ b/website/pages/playground/_Playground.tsx
@@ -489,6 +489,7 @@ export default function Playground() {
                 originalBytes={originalBytesRef.current.byteLength}
                 result={resultData}
                 op={resultOp}
+                inputFormat={meta?.format}
               />
             )}
         </div>

--- a/website/pages/playground/_Result.tsx
+++ b/website/pages/playground/_Result.tsx
@@ -18,16 +18,18 @@ export default function Result({
   originalBytes,
   result,
   op,
+  inputFormat,
 }: {
   originalUrl: string
   originalBytes: number
   result: { url: string | null; bytes: number; outFormat: string }
   op: Op
+  inputFormat?: string
 }) {
   const [copied, setCopied] = useState(false)
 
   const pct = Math.round((1 - result.bytes / originalBytes) * 100)
-  const snippet = snippetFor(op)
+  const snippet = snippetFor(op, inputFormat)
 
   const handleCopy = () => {
     navigator.clipboard.writeText(snippet).then(() => {

--- a/website/pages/playground/_snippet.ts
+++ b/website/pages/playground/_snippet.ts
@@ -15,12 +15,17 @@ function encodeCall(format: ConvertFormat, quality: number): string {
   }
 }
 
-export function snippetFor(op: Op): string {
-  if (op.kind === 'metadata') return `await new Transformer(input).metadata(true)`
+export function snippetFor(op: Op, inputFormat?: string): string {
+  // SVG has no raster magic bytes, so `new Transformer(input)` can't decode it (image::guess_format
+  // throws); it must be constructed via `Transformer.fromSvg(input)`, matching what the playground
+  // worker does. Compress ops are JPEG/PNG-only and are disabled for SVG, so only the
+  // Transformer-based ops need the swapped constructor.
+  const ctor = inputFormat === 'svg' ? 'Transformer.fromSvg(input)' : 'new Transformer(input)'
+  if (op.kind === 'metadata') return `await ${ctor}.metadata(true)`
   if (op.kind === 'convert') {
     if (op.format === 'avif')
-      return `await new Transformer(input).avif({ quality: ${op.quality}, chromaSubsampling: ChromaSubsampling.${CHROMA_NAME[op.chroma]} })`
-    return `await new Transformer(input)${encodeCall(op.format, op.quality)}`
+      return `await ${ctor}.avif({ quality: ${op.quality}, chromaSubsampling: ChromaSubsampling.${CHROMA_NAME[op.chroma]} })`
+    return `await ${ctor}${encodeCall(op.format, op.quality)}`
   }
   if (op.kind === 'compress') {
     if (op.codec === 'jpeg') return `await compressJpeg(input, { quality: ${op.quality} })`
@@ -28,7 +33,7 @@ export function snippetFor(op: Op): string {
     return `await pngQuantize(input, { maxQuality: ${op.maxQuality} })`
   }
   // transform
-  const parts: string[] = ['new Transformer(input)']
+  const parts: string[] = [ctor]
   if (op.rotate === 'auto') parts.push(`.rotate()`)
   else if (typeof op.rotate === 'number') parts.push(`.rotate(Orientation.${ORI_NAME[op.rotate] ?? 'Horizontal'})`)
   if (op.resize.enabled)

--- a/website/pages/playground/worker.ts
+++ b/website/pages/playground/worker.ts
@@ -26,6 +26,35 @@ if (typeof (globalThis as { Buffer?: unknown }).Buffer === 'undefined') {
 
 type Mod = typeof import('@napi-rs/image')
 
+// SVG is XML text, so it has no binary magic bytes: the generic `new Transformer(bytes)` path
+// routes through the wasm's `image::guess_format`, which has no SVG signature and throws
+// "Guess format from input image failed". The binding decodes SVG only through the dedicated
+// `Transformer.fromSvg`, which rasterizes via resvg. Sniff the bytes here and pick that path.
+//
+// Detection: every raster format the binding handles starts with binary magic bytes (never '<'),
+// so first require the markup to open with '<' (after an optional UTF-8 BOM and leading
+// whitespace), then look for an <svg> root element. The element name may carry an XML namespace
+// prefix (e.g. `<s:svg xmlns:s="http://www.w3.org/2000/svg">`), which usvg/fromSvg accepts, so
+// match an optional `prefix:` and require the name to be exactly `svg` (the trailing [\s/>] rules
+// out longer names like `<svgfoo>`). A plain `<svg ...>`, an `<?xml?>`/`<!DOCTYPE>` prolog, or a
+// BOM-prefixed document all reach this test.
+const SVG_ROOT = /<(?:[A-Za-z_][\w.-]*:)?svg[\s/>]/i
+function looksLikeSvg(u8: Uint8Array): boolean {
+  let i = 0
+  if (u8[0] === 0xef && u8[1] === 0xbb && u8[2] === 0xbf) i = 3 // skip UTF-8 BOM
+  while (i < u8.length && (u8[i] === 0x09 || u8[i] === 0x0a || u8[i] === 0x0d || u8[i] === 0x20)) i++
+  if (u8[i] !== 0x3c /* '<' */) return false
+  const head = new TextDecoder('utf-8', { fatal: false }).decode(u8.subarray(i, i + 65536))
+  return SVG_ROOT.test(head)
+}
+
+// Build the base Transformer, decoding SVG inputs through `fromSvg` and everything else through
+// the raster constructor. Both yield a Transformer whose metadata()/encoders/transforms work the
+// same, so callers stay format-agnostic.
+function makeTransformer(mod: Mod, u8: Uint8Array) {
+  return looksLikeSvg(u8) ? mod.Transformer.fromSvg(u8) : new mod.Transformer(u8)
+}
+
 function toArrayBuffer(out: Uint8Array): ArrayBuffer {
   // Copy into a FRESH regular ArrayBuffer. The wasm runs with threads, so its
   // Memory is `shared: true` and HEAPU8.buffer is a SharedArrayBuffer; if the
@@ -38,7 +67,7 @@ function toArrayBuffer(out: Uint8Array): ArrayBuffer {
 }
 
 async function runConvert(mod: Mod, u8: Uint8Array, op: ConvertOp): Promise<Uint8Array> {
-  const t = new mod.Transformer(u8)
+  const t = makeTransformer(mod, u8)
   switch (op.format) {
     case 'webp': return t.webp(op.quality)
     case 'webpLossless': return t.webpLossless()
@@ -64,7 +93,7 @@ async function runCompress(mod: Mod, u8: Uint8Array, op: CompressOp): Promise<Ui
 }
 
 async function runTransform(mod: Mod, u8: Uint8Array, op: TransformOp): Promise<Uint8Array> {
-  let t = new mod.Transformer(u8)
+  let t = makeTransformer(mod, u8)
   if (op.rotate === 'auto') t = t.rotate()
   else if (typeof op.rotate === 'number') t = t.rotate(op.rotate)
   if (op.resize.enabled) t = t.resize(op.resize.width, op.resize.height, op.resize.filter, op.resize.fit)
@@ -88,7 +117,7 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
     const mod: Mod = await import('@napi-rs/image')
     const u8 = new Uint8Array(bytes)
     if (op.kind === 'metadata') {
-      const m = await new mod.Transformer(u8).metadata(true)
+      const m = await makeTransformer(mod, u8).metadata(true)
       post({ id, ok: true, kind: 'metadata', meta: { width: m.width, height: m.height, format: m.format, orientation: m.orientation } })
       return
     }


### PR DESCRIPTION
## Problem

The browser playground rejected every SVG upload with **`Error: Guess format from input image failed`**, right after the file was selected.

```
SVG upload → worker: new Transformer(bytes).metadata()
          → Rust ThreadsafeDynamicImage::get()
          → image::guess_format(bytes)   ← SVG is XML text, no magic bytes → Err
          → playground shows the error
```

The binding *can* decode SVG — but only through the dedicated `Transformer.fromSvg` (resvg), which the worker never called.

## Fix

Sniff the bytes in the worker and route SVG through `Transformer.fromSvg` for **metadata / convert / transform**:

```
looksLikeSvg(bytes) ──yes──▶ Transformer.fromSvg(u8)
                  └──no───▶ new Transformer(u8)   (raster path unchanged)
```

- The sniffer first requires the markup to open with `<` (raster formats never do), then matches an `<svg>` root after an optional UTF-8 BOM / whitespace / prolog. It allows an XML **namespace-prefixed** root (`<s:svg xmlns:s="…">`) that `usvg`/`fromSvg` accepts but a literal `<svg` check would miss.
- **Compress** is left unchanged: it is JPEG/PNG-only and the UI already disables it for `format === "svg"` (which `fromSvg` reports), so SVG bytes never reach the PNG/JPEG-only compressors.
- The copyable **code snippet** is now SVG-aware — it shows `Transformer.fromSvg(input)` for SVG inputs instead of the unrunnable `new Transformer(input)`.

## Verification

- Confirmed the wasm the playground loads (`@napi-rs/image-wasm32-wasi` 1.14.0) registers `fromSvg` and reports `format: "svg"`.
- Probed the real binding to confirm the namespace-prefixed sniffer gap, then verified the broadened regex fixes it with no false positives on raster magic bytes.
- New Playwright specs drive the **real worker + wasm**:
  - plain SVG → decode, format shown, Compress disabled, convert → `done`, snippet shows `fromSvg`
  - namespace-prefixed SVG root → decodes (sniffer regression)
- `tsc --noEmit` clean; full e2e suite green.

## Note (pre-existing, out of scope)
`vite dev` does a one-time full reload when the worker first imports the wasm deps. The new SVG specs absorb it via `expect(...).toPass(...)`; the existing `playground-smoke.spec.ts` has no such guard and can flake on a stone-cold vite cache. Happy to harden it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the WASM worker decode path for a new input class; raster paths are untouched, but incorrect sniffing could mis-route rare edge cases.
> 
> **Overview**
> Fixes SVG uploads failing with **Guess format from input image failed** by routing vector inputs through **`Transformer.fromSvg`** instead of **`new Transformer(bytes)`**.
> 
> The playground::playground worker** now sniffs bytes (optional BOM/whitespace, leading `<`, regex for plain or **namespace-prefixed** `<svg>` roots) and uses a shared **`makeTransformer`** for metadata, convert, and transform. Raster handling and **compress** (JPEG/PNG-only) are unchanged.
> 
> The **copyable code snippet** takes **`inputFormat`** from the UI and emits **`Transformer.fromSvg(input)`** when the decoded format is `svg`. **Playwright** specs cover plain SVG (format label, compress disabled, convert output, snippet) and a prefixed-root regression fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bbd8f951e841f5edb78db271ad9740f739159dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->