### PR TITLE
chore: upgrade @napi-rs/cli to 3.8.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -362,10 +362,11 @@ jobs:
         with:
           name: bindings-${{ matrix.settings.target }}
           path: artifacts
-      - name: Create npm dirs
-        run: yarn workspace @napi-rs/image napi create-npm-dirs
-      - name: Move artifacts
-        run: yarn artifacts
+      - name: Install artifact
+        run: |
+          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
+          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
+          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R .
@@ -405,10 +406,11 @@ jobs:
         with:
           name: bindings-x86_64-unknown-linux-gnu
           path: artifacts
-      - name: Create npm dirs
-        run: yarn workspace @napi-rs/image napi create-npm-dirs
-      - name: Move artifacts
-        run: yarn artifacts
+      - name: Install artifact
+        run: |
+          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
+          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
+          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R .
@@ -440,10 +442,11 @@ jobs:
         with:
           name: bindings-x86_64-unknown-linux-musl
           path: artifacts
-      - name: Create npm dirs
-        run: yarn workspace @napi-rs/image napi create-npm-dirs
-      - name: Move artifacts
-        run: yarn artifacts
+      - name: Install artifact
+        run: |
+          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
+          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
+          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R .
@@ -470,10 +473,11 @@ jobs:
           path: artifacts
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build
-      - name: Create npm dirs
-        run: yarn workspace @napi-rs/image napi create-npm-dirs
-      - name: Move artifacts
-        run: yarn artifacts
+      - name: Install artifact
+        run: |
+          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
+          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
+          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R packages
@@ -503,10 +507,11 @@ jobs:
           path: artifacts
       - name: Install dependencies
         run: yarn install --immutable --mode=skip-build
-      - name: Create npm dirs
-        run: yarn workspace @napi-rs/image napi create-npm-dirs
-      - name: Move artifacts
-        run: yarn artifacts
+      - name: Install artifact
+        run: |
+          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
+          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
+          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R packages

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -210,13 +210,26 @@ jobs:
         run: ${{ matrix.settings.build }}
         if: ${{ !matrix.settings.docker }}
         shell: bash
-      - name: Upload artifact
+      - name: Upload native artifact
+        if: matrix.settings.target != 'wasm32-wasip1-threads'
+        uses: actions/upload-artifact@v7
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: packages/binding/*.node
+          if-no-files-found: error
+      - name: Upload WASI artifact
+        if: matrix.settings.target == 'wasm32-wasip1-threads'
         uses: actions/upload-artifact@v7
         with:
           name: bindings-${{ matrix.settings.target }}
           path: |
-            packages/binding/*.node
             packages/binding/image.wasm32-wasi.wasm
+            packages/binding/image.wasi.cjs
+            packages/binding/image.wasi.d.cts
+            packages/binding/image.wasi-browser.js
+            packages/binding/wasi-worker.mjs
+            packages/binding/wasi-worker-browser.mjs
+            packages/binding/index.js
           if-no-files-found: error
 
   build-armv7-linux-gnueabihf:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -364,9 +364,10 @@ jobs:
           path: artifacts
       - name: Install artifact
         run: |
-          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
-          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
-          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          test -n "$IMAGE_ARTIFACT_FILE"
+          test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
+          cp "$IMAGE_ARTIFACT_FILE" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R .
@@ -408,9 +409,10 @@ jobs:
           path: artifacts
       - name: Install artifact
         run: |
-          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
-          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
-          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          test -n "$IMAGE_ARTIFACT_FILE"
+          test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
+          cp "$IMAGE_ARTIFACT_FILE" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R .
@@ -444,9 +446,10 @@ jobs:
           path: artifacts
       - name: Install artifact
         run: |
-          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
-          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
-          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          test -n "$IMAGE_ARTIFACT_FILE"
+          test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
+          cp "$IMAGE_ARTIFACT_FILE" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R .
@@ -475,9 +478,10 @@ jobs:
         run: yarn install --immutable --mode=skip-build
       - name: Install artifact
         run: |
-          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
-          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
-          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          test -n "$IMAGE_ARTIFACT_FILE"
+          test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
+          cp "$IMAGE_ARTIFACT_FILE" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R packages
@@ -509,9 +513,10 @@ jobs:
         run: yarn install --immutable --mode=skip-build
       - name: Install artifact
         run: |
-          mapfile -t IMAGE_ARTIFACT_FILES < <(find artifacts -type f -name '*.node')
-          test "${#IMAGE_ARTIFACT_FILES[@]}" -eq 1
-          cp "${IMAGE_ARTIFACT_FILES[0]}" packages/binding/
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          test -n "$IMAGE_ARTIFACT_FILE"
+          test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
+          cp "$IMAGE_ARTIFACT_FILE" packages/binding/
         shell: bash
       - name: List packages
         run: ls -R packages

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -377,7 +377,7 @@ jobs:
           path: artifacts
       - name: Install artifact
         run: |
-          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node')
           test -n "$IMAGE_ARTIFACT_FILE"
           test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
           cp "$IMAGE_ARTIFACT_FILE" packages/binding/
@@ -422,7 +422,7 @@ jobs:
           path: artifacts
       - name: Install artifact
         run: |
-          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node')
           test -n "$IMAGE_ARTIFACT_FILE"
           test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
           cp "$IMAGE_ARTIFACT_FILE" packages/binding/
@@ -459,7 +459,7 @@ jobs:
           path: artifacts
       - name: Install artifact
         run: |
-          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node')
           test -n "$IMAGE_ARTIFACT_FILE"
           test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
           cp "$IMAGE_ARTIFACT_FILE" packages/binding/
@@ -491,7 +491,7 @@ jobs:
         run: yarn install --immutable --mode=skip-build
       - name: Install artifact
         run: |
-          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node')
           test -n "$IMAGE_ARTIFACT_FILE"
           test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
           cp "$IMAGE_ARTIFACT_FILE" packages/binding/
@@ -526,7 +526,7 @@ jobs:
         run: yarn install --immutable --mode=skip-build
       - name: Install artifact
         run: |
-          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node' -print -quit)
+          IMAGE_ARTIFACT_FILE=$(find artifacts -type f -name '*.node')
           test -n "$IMAGE_ARTIFACT_FILE"
           test "$(find artifacts -type f -name '*.node' | wc -l | tr -d ' ')" -eq 1
           cp "$IMAGE_ARTIFACT_FILE" packages/binding/

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "website"
   ],
   "devDependencies": {
-    "@napi-rs/cli": "3.7.4",
+    "@napi-rs/cli": "3.8.3",
     "@taplo/cli": "^0.7.0",
     "@types/node": "^24.10.1",
     "@types/sharp": "^0.32.0",

--- a/packages/binding/package.json
+++ b/packages/binding/package.json
@@ -72,7 +72,9 @@
   },
   "repository": "git@github.com:Brooooooklyn/Image.git",
   "devDependencies": {
-    "@napi-rs/cli": "3.7.4",
-    "@napi-rs/wasm-runtime": "^1.1.5"
+    "@emnapi/core": "2.0.0-alpha.3",
+    "@emnapi/runtime": "2.0.0-alpha.3",
+    "@napi-rs/cli": "3.8.3",
+    "@napi-rs/wasm-runtime": "1.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "@emnapi/core@npm:2.0.0-alpha.3"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:2.0.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/dfc26f53eb40dab0e316206cabe01e6e98d21ef8a0b820f81ce7e0fa7b4307c94f2a9599c11e6c601ad7bd77e8efb9b7cb9f86dbc3b6237f799405e0cb60c587
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
@@ -356,6 +366,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "@emnapi/runtime@npm:2.0.0-alpha.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/c8f6e0ad2f9c0ced8bc156a7ec3ab5fbbd2d3b7147b6a37537f6892131844b969d3aa450749807fc238160b5db61d6160b8066abfce4b2c40acfb1941bb31dd1
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.1":
   version: 1.2.1
   resolution: "@emnapi/wasi-threads@npm:1.2.1"
@@ -371,6 +390,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/f0dc8269d6b20ae5a7c7b36e7a6a333452009d461038ef4febb29da2f3f78c1e2b1576d7e8970a5c5789ed3caedc1f80f5b0c2a5373bdaf8d03b20432bb55747
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@emnapi/wasi-threads@npm:2.0.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/5f7bf4cc4f6a1c31ec2084c9321d054f3b3b6c7e89430bb23fc3487d55e7be40f1ff31b2cb9a51721b444d4e8ac1f065b8749606771f6e4e7ccb32bbb709a303
   languageName: node
   linkType: hard
 
@@ -2172,9 +2200,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/cli@npm:3.7.4":
-  version: 3.7.4
-  resolution: "@napi-rs/cli@npm:3.7.4"
+"@napi-rs/cli@npm:3.8.3":
+  version: 3.8.3
+  resolution: "@napi-rs/cli@npm:3.8.3"
   dependencies:
     "@inquirer/prompts": "npm:^8.5.2"
     "@napi-rs/cross-toolchain": "npm:^1.0.3"
@@ -2182,21 +2210,22 @@ __metadata:
     "@octokit/rest": "npm:^22.0.1"
     clipanion: "npm:^4.0.0-rc.4"
     colorette: "npm:^2.0.20"
-    emnapi: "npm:^1.11.1"
+    emnapi: "npm:2.0.0-alpha.3"
     es-toolkit: "npm:^1.47.0"
     js-yaml: "npm:^4.2.0"
     obug: "npm:^2.1.2"
     semver: "npm:^7.8.2"
     typanion: "npm:^3.14.0"
+    typescript: "npm:^6.0.3"
   peerDependencies:
-    "@emnapi/runtime": ^1.7.1
+    "@emnapi/runtime": 2.0.0-alpha.3
   peerDependenciesMeta:
     "@emnapi/runtime":
       optional: true
   bin:
     napi: dist/cli.js
     napi-raw: cli.mjs
-  checksum: 10c0/03e0cc62f6b1e116e998f4ea51f0795ced8c459e680ab1662b7c650a33d8a1a0424eded3882d033443ef743ea15c5f5902e709b9bb56a7bcc7b44053aa87d89c
+  checksum: 10c0/3f9c92b13343f630de84ac7cd412fbebe7d2bdb68401f0baeea3eff27afd07ec4fdc4bb212a9896def4b1dc2b968ca04753ea920a8dd0e07ccd9cb367b7d081b
   languageName: node
   linkType: hard
 
@@ -2408,8 +2437,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@napi-rs/image@workspace:packages/binding"
   dependencies:
-    "@napi-rs/cli": "npm:3.7.4"
-    "@napi-rs/wasm-runtime": "npm:^1.1.5"
+    "@emnapi/core": "npm:2.0.0-alpha.3"
+    "@emnapi/runtime": "npm:2.0.0-alpha.3"
+    "@napi-rs/cli": "npm:3.8.3"
+    "@napi-rs/wasm-runtime": "npm:1.2.2"
   languageName: unknown
   linkType: soft
 
@@ -2902,6 +2933,18 @@ __metadata:
     "@emnapi/runtime": "npm:^1.1.0"
     "@tybys/wasm-util": "npm:^0.9.0"
   checksum: 10c0/1040de49b2ef509db207e2517465dbf7fb3474f20e8ec32897672a962ff4f59872385666dac61dc9dbeae3cae5dad265d8dc3865da756adeb07d1634c67b03a1
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@napi-rs/wasm-runtime@npm:1.2.2"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.3
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.3
+  checksum: 10c0/670ff8359761660f58d95a29fe22ac959d2c295675144fe9bc35118b0e723d1e0ac192df9896ba428eb13930cf0893b632606b70ccaea259fd6eca1836c2eb09
   languageName: node
   linkType: hard
 
@@ -6210,15 +6253,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"emnapi@npm:^1.11.1":
-  version: 1.11.1
-  resolution: "emnapi@npm:1.11.1"
+"emnapi@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "emnapi@npm:2.0.0-alpha.3"
   peerDependencies:
     node-addon-api: ">= 6.1.0"
   peerDependenciesMeta:
     node-addon-api:
       optional: true
-  checksum: 10c0/936a7de68b2466c59c5333b65735154ff8db16d45642af12d9fd6ff10d7e3a03c54f1101ddfb960f3f53dc393a5c38a8326beeb32962fc7a92b25c77d7047f39
+  checksum: 10c0/9d12b1454af5b201db6d671e87e4ef43d2a1253877eebd6bfe79bd6eaa9cba3c5c73c06880b4101873a6cdcd39cdd18c63565f6ebd0b388132800edec87595d8
   languageName: node
   linkType: hard
 
@@ -7494,7 +7537,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "image@workspace:."
   dependencies:
-    "@napi-rs/cli": "npm:3.7.4"
+    "@napi-rs/cli": "npm:3.8.3"
     "@taplo/cli": "npm:^0.7.0"
     "@types/node": "npm:^24.10.1"
     "@types/sharp": "npm:^0.32.0"
@@ -11532,6 +11575,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"typescript@npm:^6.0.3":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/4a25ff5045b984370f48f196b3a0120779b1b343d40b9a68d114ea5e5fff099809b2bb777576991a63a5cd59cf7bffd96ff6fe10afcefbcb8bd6fb96ad4b6606
+  languageName: node
+  linkType: hard
+
 "typescript@npm:^7.0.0":
   version: 7.0.2
   resolution: "typescript@npm:7.0.2"
@@ -11610,6 +11663,16 @@ __metadata:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/2f25c74e65663c248fa1ade2b8459d9ce5372ff9dad07067310f132966ebec1d93f6c42f0baf77a6b6a7a91460463f708e6887013aaade22111037457c6b25df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade `@napi-rs/cli` from 3.7.4 to 3.8.3 in the root and binding workspaces
- align the binding build stack on `@emnapi/core` and `@emnapi/runtime` 2.0.0-alpha.3 plus `@napi-rs/wasm-runtime` 1.2.2
- refresh the Yarn lockfile for the aligned emnapi v2 dependency graph

## Why

CI resolves current Rust dependencies because `Cargo.lock` is not committed. That moved the WASI build to `napi` 3.12.0 / `napi-build` 2.4.0, which require the emnapi v2 exports `emnapi_create_env` and `emnapi_delete_env`. CLI 3.7.4 installed emnapi 1.11.1, so `wasm-ld` could not find those exports.

CLI 3.8.3 installs emnapi 2.0.0-alpha.3 and validates that the core/runtime packages use the same generation. Aligning the complete build stack restores the threaded WASI link.

## Impact

The `wasm32-wasip1-threads` CI build can resolve current Rust crates without failing at the emnapi ABI boundary. Native targets are unaffected by the dependency-only change.

## Validation

- `yarn install --immutable`
- clean worktree with no `Cargo.lock`: `yarn workspace @napi-rs/image build --target wasm32-wasip1-threads`
  - Node 24.19.0
  - Rust 1.97.1, resolving `napi` 3.12.0 / `napi-build` 2.4.0
  - WASI SDK 33 (arm64 macOS)
- `git diff --check origin/main...HEAD`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the threaded WASI link chain and CI artifact layout; misaligned uploads or install steps could break native or WASI test lanes without affecting runtime app code directly.
> 
> **Overview**
> **Dependency stack:** `@napi-rs/cli` moves from **3.7.4** to **3.8.3** at the repo root and in `packages/binding`, with the binding workspace pinned to **emnapi 2.0.0-alpha.3** (`@emnapi/core`, `@emnapi/runtime`) and **`@napi-rs/wasm-runtime` 1.2.2**, plus an updated `yarn.lock` (including emnapi v2 and TypeScript 6 for the CLI).
> 
> **CI build artifacts:** Upload is split by target—**native** jobs upload only `packages/binding/*.node`; **`wasm32-wasip1-threads`** uploads the full WASI bundle (wasm, `image.wasi.*`, worker shims, `index.js`) and no longer includes `.node` in that artifact.
> 
> **CI test jobs:** Native binding tests drop `napi create-npm-dirs` and `yarn artifacts`; they now copy the single downloaded `.node` from `artifacts/` into `packages/binding/` with sanity checks. The **publish** job is unchanged and still uses `create-npm-dirs` and `yarn artifacts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a000dcb512a49936299665cd1c99965d3d7f8036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->